### PR TITLE
QA 수정사항 반영

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ function Footer() {
           alt={logoData.name}
           className="mx-1 xs:h-[12px] sm:h-[12px] h-[23px] xs:translate-y-[3px] sm:translate-y-[3px]"
         />
-        <h3 className="xs:text-[14px] sm:text-[14px] text-[20px] font-NeoEB">
+        <h3 className="xs:text-[14px] sm:text-[14px] text-[20px] font-Jost font-semibold">
           YOURSSU
         </h3>
       </div>

--- a/src/components/SectionIntro.tsx
+++ b/src/components/SectionIntro.tsx
@@ -9,7 +9,7 @@ function SectionIntro({ title, description, divStyle, color }: IntroProps) {
   return (
     <div className="flex flex-col items-center mx-[50px]">
       <div className={`xs:w-[2px] w-[3px] xs:h-[30px] h-[39px] ${divStyle}`} />
-      <h1 className="xs:mt-[30px] mt-[40px] mb-[10px] font-Jost font-medium xs:text-[20px] sm:text-[24px] md:text-[32px] text-[36px]">
+      <h1 className="xs:mt-[30px] mt-[40px] mb-[10px] font-Jost font-semibold xs:text-[20px] sm:text-[24px] md:text-[32px] text-[36px]">
         {title}
       </h1>
       {description.split('<br />').map((des) => (

--- a/src/components/TeamButton.tsx
+++ b/src/components/TeamButton.tsx
@@ -5,7 +5,7 @@ type ButtonItem = {
 
 function TeamButton({ img, name }: ButtonItem) {
   return (
-    <div className="mx-[15px] sm:mb-[24px] mb-[40px]">
+    <div className="xs:mx-[6px] sm:mx-[6px] md:mx-[12px] mx-[15px] sm:mb-[24px] mb-[40px]">
       <img
         src={img}
         alt={img}

--- a/src/container/home/project.tsx
+++ b/src/container/home/project.tsx
@@ -10,13 +10,13 @@ function Project() {
   const { data } = useCarouselDetail();
 
   return (
-    <div className="relative xs:mb-[100px] sm:mb-[200px] md:mb-[300px] mb-[350px]">
+    <div className="flex flex-col items-center relative xs:mb-[100px] sm:mb-[200px] md:mb-[300px] mb-[350px]">
       <img
-        className=" absolute -z-10 w-full top-0"
+        className="w-full h-[446px] sm:h-[357px] xs:h-[300px]"
         src={data.backgroundImgData.nodes[0].publicURL}
         alt={data.backgroundImgData.nodes[0].name}
       />
-      <div className="xs:pt-[50px] sm:pt-[60px] pt-[80px]">
+      <div className="absolute xs:pt-[50px] sm:pt-[60px] pt-[80px]">
         {windowSize ? (
           <SectionIntro
             title="Project"

--- a/src/hooks/container/team/hook.ts
+++ b/src/hooks/container/team/hook.ts
@@ -14,7 +14,10 @@ type Team = {
 export default function useTeamDetail() {
   const data: Team = useStaticQuery(graphql`
     query {
-      teams: allFile(filter: { sourceInstanceName: { eq: "teams" } }) {
+      teams: allFile(
+        filter: { sourceInstanceName: { eq: "teams" } }
+        sort: { order: ASC, fields: name }
+      ) {
         nodes {
           publicURL
           name


### PR DESCRIPTION
## 진행 사항
* 팀 아이콘 순서를 graphql에서 sort해서 랜덤 순서였던 것을 해결했습니다.
* 720, 390 사이즈에서 팀 아이콘 간격을 피그마를 참고해서 재설정 했습니다.
* 제가 담당했던 부분인 SectionIntro와 Footer에서 Jost 폰트로 변경했고 두께도 피그마를 참고해서 설정했습니다.
* 프로젝트 섹션에서 SectionIntro의 배경이 되는 그라데이션 이미지의 높이를 조절해서 피그마 모습대로 설정했습니다.