### PR TITLE
[디자인팀 QA] 부서 상세 페이지 및 랜딩 페이지 수정

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -11,6 +11,16 @@ interface QueryResult {
       };
     }[];
   };
+  allSanityRecruitingSchedule: {
+    edges: {
+      node: {
+        applyProcedure: {
+          schedule: string;
+          step: string;
+        }[];
+      };
+    }[];
+  };
 }
 
 const path = require('path');
@@ -42,6 +52,16 @@ export const createPages: GatsbyNode['createPages'] = async ({
           }
         }
       }
+      allSanityRecruitingSchedule {
+        edges {
+          node {
+            applyProcedure {
+              schedule
+              step
+            }
+          }
+        }
+      }
     }
   `);
 
@@ -59,6 +79,11 @@ export const createPages: GatsbyNode['createPages'] = async ({
     (edge) => edge.node.basicInformation.name,
   );
 
+  const schedule =
+    queryAllSanityData.data?.allSanityRecruitingSchedule.edges[
+      queryAllSanityData.data.allSanityRecruitingSchedule.edges.length - 1
+    ].node.applyProcedure;
+
   const generateDescriptionPage = ({
     node: {
       basicInformation: { name },
@@ -73,7 +98,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
     const pageOptions = {
       path: `recruiting/${name.toLowerCase().replaceAll(' ', '_')}`,
       component: DescriptionTemplateComponent,
-      context: { name, nameList },
+      context: { name, nameList, schedule },
     };
 
     createPage(pageOptions);

--- a/src/components/Button/ApplyButton.tsx
+++ b/src/components/Button/ApplyButton.tsx
@@ -7,16 +7,23 @@ interface ApplyButtonProps {
 }
 
 function ApplyButton({ link, $testSize }: ApplyButtonProps) {
+  if (link)
+    return (
+      <ActiveContainer to={link} $testSize={$testSize}>
+        지원하기
+      </ActiveContainer>
+    );
+
   return (
-    <Container to={link} $testSize={$testSize}>
-      지원하기
-    </Container>
+    <NoActiveContainer $testSize={$testSize}>
+      지원 기간이 아닙니다
+    </NoActiveContainer>
   );
 }
 
 export default ApplyButton;
 
-const Container = tw(Link)<{ $testSize: string }>`
+const ActiveContainer = tw(Link)<{ $testSize: string }>`
   ${(props) => props.$testSize}
   w-full
   rounded-[12px]
@@ -26,4 +33,16 @@ const Container = tw(Link)<{ $testSize: string }>`
   py-5
   text-center
   text-white-0
+`;
+
+const NoActiveContainer = tw.button<{ $testSize: string }>`
+  ${(props) => props.$testSize}
+  w-full
+  rounded-[12px]
+  bg-bluegray3-0
+  py-5
+  text-center
+  text-bluegray1-0
+
+  cursor-default
 `;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -24,7 +24,7 @@ function Header({ type, pageType }: Props) {
       }`}
     >
       <div className="flex w-full items-center justify-between py-[24px] xs:px-[20px] xs:py-[12px] sm:px-[20px] sm:py-[12px] md:px-[40px] md:py-[24px] lg:px-[40px] lg:py-[24px] xl:w-[1326px] xxl:w-[1326px]">
-        <div className="flex items-center justify-between">
+        <Link to="/" className="flex items-center justify-between">
           <img
             src={logoData.publicURL}
             alt={logoData.name}
@@ -39,7 +39,7 @@ function Header({ type, pageType }: Props) {
               YOURSSU
             </span>
           )}
-        </div>
+        </Link>
         <div className="flex flex-row items-center gap-[24px] xs:hidden sm:hidden">
           <Link to="/">
             <span

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -84,7 +84,7 @@ function Header({ type, pageType }: Props) {
         } block h-[1px] w-full border-none bg-bluegray2-0`}
       />
       {isClick ? (
-        <nav className="flex h-auto w-full flex-col items-start justify-start md:hidden lg:hidden xl:hidden xxl:hidden ">
+        <nav className="flex h-auto w-full flex-col items-start justify-start bg-white-0 md:hidden lg:hidden xl:hidden xxl:hidden">
           <span
             className={`
               p-[20px]

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -81,7 +81,7 @@ function Header({ type, pageType }: Props) {
       <hr
         className={`${
           isClick ? 'hidden' : null
-        } block h-[1px] w-full border-none bg-bluegray2-0`}
+        } block h-[1px] w-full border-none ${pageType !== 'main' && 'bg-bluegray2-0'}`}
       />
       {isClick ? (
         <nav className="flex h-auto w-full flex-col items-start justify-start bg-white-0 md:hidden lg:hidden xl:hidden xxl:hidden">

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -12,7 +12,7 @@ function Layout({ children, type, pageType }: Props) {
   return (
     <div
       className={`relative ${
-        pageType === 'recruiting' ? 'overflow-auto bg-bluegray4-0' : null
+        pageType === 'recruiting' ? 'bg-bluegray4-0' : null
       }`}
     >
       <Header pageType={pageType} type={type} />

--- a/src/containers/description/ApplyProcedure/index.tsx
+++ b/src/containers/description/ApplyProcedure/index.tsx
@@ -142,7 +142,7 @@ const ProcedureStep = tw.div`
   
   min-w-max
   
-  font-PrtendardR
+  font-PretendardR
   text-xl
   leading-9
   text-gray1-0

--- a/src/containers/description/TeamHeader/index.tsx
+++ b/src/containers/description/TeamHeader/index.tsx
@@ -82,10 +82,10 @@ const TeamIntroInnerContainer = tw.div`
 `;
 
 const Title = tw.div`
-  body2
-  md:body5
-  sm:body8
-  xs:body8
+  h4
+  md:body4
+  sm:body6
+  xs:body6
   text-black-0
 `;
 

--- a/src/containers/description/TeamHeader/index.tsx
+++ b/src/containers/description/TeamHeader/index.tsx
@@ -17,9 +17,15 @@ function TeamHeader({
             <TeamName>{basicInformation.name}</TeamName>
             <Description>{basicInformation.long_introduction}</Description>
           </TeamIntroInnerContainer>
-          <Link to={basicInformation.apply_link}>
-            <ApplyButton>바로 지원하기</ApplyButton>
-          </Link>
+          {basicInformation.apply_link ? (
+            <Link to={basicInformation.apply_link}>
+              <ApplyButton>바로 지원하기</ApplyButton>
+            </Link>
+          ) : (
+            <div>
+              <NoApplyButton>지원 기간이 아닙니다</NoApplyButton>
+            </div>
+          )}
         </TeamIntroContainer>
         <TeamImageContainer>
           <TeamImage
@@ -117,6 +123,25 @@ const ApplyButton = tw.button`
   md:py-3
   sm:py-3
   xs:py-3
+`;
+
+const NoApplyButton = tw.button`
+  body4
+  md:body6
+  sm:body6
+  xs:body6
+  text-bluegray1-0
+
+  rounded-[50px]
+  bg-bluegray2-0
+
+  px-7
+  py-[14px]
+  md:py-3
+  sm:py-3
+  xs:py-3
+
+  cursor-default
 `;
 
 const TeamImageContainer = tw.div`

--- a/src/templates/DescriptionTemplate.tsx
+++ b/src/templates/DescriptionTemplate.tsx
@@ -21,7 +21,7 @@ import {
   SkillContentInformation,
 } from '@/types/recruiting.type';
 
-interface SanityDeparmentData {
+interface SanityDepartmentData {
   allSanityDepartment: {
     edges: {
       node: {
@@ -37,11 +37,13 @@ interface SanityDeparmentData {
     }[];
   };
 }
+
 interface DescriptionTemplateProps {
-  data: SanityDeparmentData;
+  data: SanityDepartmentData;
   pageContext: {
     name: string;
     nameList: string[];
+    schedule: ApplyProcedureInformation[];
   };
 }
 
@@ -49,7 +51,7 @@ function DescriptionTemplate({
   data: {
     allSanityDepartment: { edges },
   },
-  pageContext: { name, nameList },
+  pageContext: { name, nameList, schedule },
 }: DescriptionTemplateProps) {
   const [type, setType] = useState<OSType>();
   const breakpoints = useBreakpoint();
@@ -78,7 +80,13 @@ function DescriptionTemplate({
                 experience={edges[0].node.experience}
                 skill={edges[0].node.skill}
               />
-              <ApplyProcedure applyProcedure={edges[0].node.applyProcedure} />
+              <ApplyProcedure
+                applyProcedure={
+                  edges[0].node.applyProcedure.length === 0
+                    ? schedule
+                    : edges[0].node.applyProcedure
+                }
+              />
             </DefaultInformationContainer>
             <Line />
             <RoadToPro roadToPro={edges[0].node.roadToProVideo} />
@@ -117,7 +125,7 @@ export default DescriptionTemplate;
 export function Head({
   data: { allSanityDepartment },
 }: {
-  data: SanityDeparmentData;
+  data: SanityDepartmentData;
 }) {
   return (
     <DepartmentSeo


### PR DESCRIPTION
## 개요

- 디자인 팀 QA 사항에 대해 부서 상세 페이지와 헤더를 수정했습니다.

## 작업사항

### 부서 상세 페이지
- 팀에서 구체적인 지원 절차가 없다면, 공통 지원 절차 일정을 받아와서 보여주는 방식으로 수정
- 채용하지 않는 부서는 지원 버튼이 활성화되지 않도록 수정
- 네비게이션 바 sticky 적용 안되는 문제 수정
- 팀 한 줄 소개 디자인 수정사항 반영

### 헤더
- 로고 클릭하면 랜딩 페이지로 이동하도록 수정
- 랜딩페이지에서 헤더의 bottom border 안 보이도록 수정
