### PR TITLE
hotfix: FAQ 텍스트 수정

### DIFF
--- a/src/containers/select/FAQ/hook.ts
+++ b/src/containers/select/FAQ/hook.ts
@@ -66,7 +66,7 @@ export default function useFAQDetail() {
     },
     {
       question: '동아리 회비가 있나요?',
-      answer: '동아리 회비는 지난 학기 기준 학기 당 20,000원입니다.',
+      answer: '동아리 회비는 이번 학기 기준 학기 당 20,000원입니다.',
     },
   ];
 


### PR DESCRIPTION
## 개요

- FAQ 텍스트를 수정했습니다

## 작업사항

- `지난 학기` -> `이번 학기`로 수정했습니다. (브랜치 생성과 PR 날리기 민망하네요..ㅎ)
