### PR TITLE
fix: 모바일에서 부서카드 터치가 안되던 문제 수정

### DIFF
--- a/src/containers/select/Supporting/DepartmentCard.tsx
+++ b/src/containers/select/Supporting/DepartmentCard.tsx
@@ -21,10 +21,10 @@ export default function DepartmentCard({
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <motion.div
+    <div
       className="flex justify-center"
-      onHoverStart={() => setIsHovered(true)}
-      onHoverEnd={() => setIsHovered(false)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <Container>
         {isHovered && (
@@ -55,7 +55,7 @@ export default function DepartmentCard({
           <DepartmentImg src={data.imgData.publicURL} alt={data.imgData.name} />
         </Stack>
       </Container>
-    </motion.div>
+    </div>
   );
 }
 


### PR DESCRIPTION
hover 로직을 framer-motion의 onHover에서 native onMouse 이벤트로 변경했어요.