### PR TITLE
[#94] MVC 섹션 스크롤 튕김 문제 해결

### DIFF
--- a/src/containers/landing/MVC/new/index.tsx
+++ b/src/containers/landing/MVC/new/index.tsx
@@ -1,7 +1,6 @@
 import {
   useMotionValueEvent,
   useScroll,
-  useTransform,
   AnimatePresence,
   motion,
 } from 'framer-motion';
@@ -25,17 +24,12 @@ function MissionVision() {
       Math.floor(latest * contentData.length),
       contentData.length - 1,
     );
+
     setCurrentIndex(newIndex);
   });
 
   // 현재 인덱스에 맞는 콘텐츠를 가져옵니다.
   const activeContent = contentData[currentIndex];
-
-  const height = useTransform(
-    scrollYProgress,
-    [0, 0.1, 0.9, 1],
-    ['37.5rem', '100vh', '100vh', '37.5rem'],
-  );
 
   return (
     <section
@@ -43,10 +37,7 @@ function MissionVision() {
       style={{ height: `${contentData.length * 100}vh` }}
       className="relative mb-[6.75rem] mt-40 xs:hidden sm:hidden md:hidden"
     >
-      <motion.div
-        style={{ height }}
-        className="sticky top-0 flex w-full items-center justify-center bg-white-0"
-      >
+      <motion.div className="sticky top-0 flex h-screen w-full items-center justify-center bg-white-0">
         {/* 비전 콘텐츠가 들어가는 div */}
         <div className="flex h-[37.5rem] w-full min-w-96 max-w-full flex-col items-center justify-center bg-[#F6F6F6]">
           <AnimatePresence mode="wait">
@@ -61,7 +52,7 @@ function MissionVision() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
-              transition={{ duration: 0.5 }}
+              transition={{ duration: 0.3, ease: 'easeOut' }}
             >
               <div className="flex flex-col items-center gap-1">
                 <div className="T3_Sb_20 text-[#4B505D]">


### PR DESCRIPTION
 ## 개요

 - MVC 섹션 스크롤 시 화면이 중앙으로 강제로 이동하는 튕김 현상 해결
  - 동적 height transform과 sticky positioning의 충돌로 인한 레이아웃 재계산 문제 수정
  - 관련 이슈: Closes #94

### AS-IS

https://github.com/user-attachments/assets/7ef4d2fb-c86e-4627-8f13-8528ef5fa9a3

### TO-BE

https://github.com/user-attachments/assets/4b0cefe4-1a5e-4cbd-8eb4-6a8d3f980304

  ## 작업사항

  ### 1. 동적 height transform 제거
  - `useTransform`을 사용한 동적 높이 계산 로직 제거
  - `style={{ height }}` 제거하고 고정 높이 `h-screen` className 적용
  - 레이아웃 재계산(reflow) 완전 제거로 스크롤 위치 강제 조정 문제 해결

  ### 2. 애니메이션 최적화
  - transition duration: 0.5초 → 0.3초로 단축
  - ease 함수 추가: `easeOut` (더 자연스러운 전환)

  ### 3. 코드 정리
  - 사용하지 않는 `useTransform` import 제거

  ## 참고사항

  ### 기술적 배경
  동적으로 높이를 변경(`37.5rem` ↔ `100vh`)하면서 sticky positioning을 사용하면:
  1. 스크롤 시 높이가 지속적으로 변경
  2. 브라우저가 레이아웃을 재계산(reflow)
  3. Sticky 요소의 위치가 재조정되면서 스크롤 위치 강제 이동
  4. 사용자에게 "튕김" 현상으로 인지됨

  고정 높이(`h-screen`)를 사용하면 레이아웃 재계산이 발생하지 않아 문제 해결