### PR TITLE
chore: 배포 인증을 AWS OIDC로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout source code
         # v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: master
+          persist-credentials: false
 
       - name: Setup pnpm
         # v6.0.3
@@ -50,9 +54,14 @@ jobs:
       - name: Build application
         run: pnpm gatsby build
 
+      - name: Configure AWS credentials
+        # v6.2.3
+        uses: "aws-actions/configure-aws-credentials@\
+          e6de054238d6b7531b4efff3b6587d9aade6a06c"
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: GitHubActions-${{ github.run_id }}
+          aws-region: ap-northeast-2
+
       - name: Deploy to S3 using gatsby-plugin-s3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
         run: pnpm gatsby-plugin-s3 deploy --yes


### PR DESCRIPTION
## 개요

- 장기 AWS 액세스 키 대신 GitHub Actions OIDC로 임시 자격 증명을 발급받아 S3에 배포합니다.
- 만료된 `AWS_ACCESS_KEY_ID`로 인해 배포가 실패하는 문제를 해소하고, 저장소에 장기 AWS 자격 증명을 보관하지 않도록 변경합니다.

## 작업사항

- 배포 job에 `id-token: write`, `contents: read` 최소 권한을 설정했습니다.
- `aws-actions/configure-aws-credentials` v6.2.3을 commit SHA로 고정해 AWS IAM Role을 assume하도록 추가했습니다.
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` 주입을 제거했습니다.
- checkout 이후 GitHub 토큰이 남지 않도록 `persist-credentials: false`를 설정했습니다.

## 동작 방식

```mermaid
flowchart LR
    A[GitHub Actions] -->|OIDC token| B[AWS IAM OIDC Provider]
    B -->|AssumeRoleWithWebIdentity| C[배포 IAM Role]
    C -->|임시 자격 증명| D[S3 yourssu.com]
```

## AWS OIDC 설정 방법

### 1. AWS IAM OIDC Provider 등록

AWS 계정에 GitHub용 Provider가 없다면 **IAM → Identity providers → Add provider → OpenID Connect**에서 아래 값으로 한 번만 등록합니다.

- Provider URL: `https://token.actions.githubusercontent.com`
- Audience: `sts.amazonaws.com`

이미 같은 Provider가 있다면 기존 Provider를 재사용합니다.

### 2. 배포용 IAM Role 생성 및 신뢰 정책 설정

`<AWS_ACCOUNT_ID>`를 실제 AWS 계정 ID로 바꾸고 Role의 Trust policy에 적용합니다.

`push` 배포는 `master`, `repository_dispatch`는 기본 브랜치인 `develop` 컨텍스트에서 실행되므로 두 ref만 허용합니다.

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
          "token.actions.githubusercontent.com:sub": [
            "repo:yourssu/yourssu.com:ref:refs/heads/master",
            "repo:yourssu/yourssu.com:ref:refs/heads/develop"
          ]
        }
      }
    }
  ]
}
```

### 3. Role에 S3 배포 권한 연결

현재 `gatsby-plugin-s3` 설정(`yourssu.com`, `ap-northeast-2`)에 필요한 최소 권한 예시입니다.

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "ManageWebsiteBucket",
      "Effect": "Allow",
      "Action": [
        "s3:GetBucketLocation",
        "s3:ListBucket",
        "s3:PutBucketWebsite"
      ],
      "Resource": "arn:aws:s3:::yourssu.com"
    },
    {
      "Sid": "DeployWebsiteObjects",
      "Effect": "Allow",
      "Action": [
        "s3:PutObject",
        "s3:DeleteObject",
        "s3:AbortMultipartUpload"
      ],
      "Resource": "arn:aws:s3:::yourssu.com/*"
    }
  ]
}
```

### 4. GitHub Actions Repository Variable 등록

**Repository Settings → Secrets and variables → Actions → Variables**에 아래 값을 등록합니다.

- Name: `AWS_ROLE_ARN`
- Value: `arn:aws:iam::<AWS_ACCOUNT_ID>:role/<ROLE_NAME>`

CLI 사용 시:

```bash
gh variable set AWS_ROLE_ARN \
  --body 'arn:aws:iam::<AWS_ACCOUNT_ID>:role/<ROLE_NAME>'
```

## 검증

- `actionlint .github/workflows/deploy.yml`
- `yamllint .github/workflows/deploy.yml`
- YAML/LSP diagnostics
- `git diff --check`
- 애플리케이션 빌드는 워크플로 파일만 변경되어 별도로 실행하지 않았습니다.

## 참고사항

- IAM Role과 `AWS_ROLE_ARN` 변수를 먼저 설정한 뒤 배포를 실행해야 합니다.
- 최초 OIDC 배포 성공 확인 후 기존 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` repository secrets는 삭제할 수 있습니다.

## 필요한 후속 작업

- [ ] AWS IAM OIDC Provider 확인 또는 등록
- [ ] 배포 IAM Role 및 S3 권한 정책 생성
- [ ] GitHub Repository Variable `AWS_ROLE_ARN` 등록
- [ ] 첫 OIDC 배포 성공 후 기존 장기 AWS credential secrets 삭제
