### PR TITLE
chore: pnpm 11.21.0으로 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.9.2"
   },
-  "packageManager": "pnpm@9.7.0+sha512.dc09430156b427f5ecfc79888899e1c39d2d690f004be70e05230b72cb173d96839587545d09429b55ac3c429c801b4dc3c0e002f653830a420fa2dd4e3cf9cf"
+  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+allowBuilds:
+  '@parcel/watcher': true
+  aws-sdk: true
+  core-js: true
+  core-js-pure: true
+  es5-ext: true
+  gatsby: true
+  gatsby-cli: true
+  lmdb: true
+  msgpackr-extract: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## 개요

- pnpm을 9.7.0에서 11.21.0으로 업데이트했습니다.

## 작업사항

- `packageManager` 버전과 무결성 해시를 갱신했습니다.
- pnpm 11에서 의존성 빌드 스크립트를 명시적으로 허용하도록 `allowBuilds`를 추가했습니다.

```mermaid
flowchart LR
    A[pnpm 11.21.0] --> B[pnpm install]
    B --> C[allowBuilds 확인]
    C --> D[Gatsby 네이티브 의존성 빌드]
```

## 참고사항

- `CI=true pnpm install --frozen-lockfile` 통과
- `pnpm exec prettier --check package.json pnpm-workspace.yaml` 통과
- `pnpm typecheck`는 기존 `src/containers/landing/Ideal/index.tsx`의 누락 모듈(`hook`, `IdealItem`) 및 암시적 `any` 오류로 실패합니다. 해당 파일은 이 PR에서 변경하지 않았습니다.

## 필요한 후속 작업

- `Ideal` 컨테이너의 기존 타입 오류 수정