### PR TITLE
ci: 배포 후 CloudFront 캐시 무효화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,3 +71,9 @@ jobs:
 
       - name: Deploy to S3
         run: pnpm deploy
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E32Z5UQBMO5UFL \
+            --paths '/*'


### PR DESCRIPTION
## Summary
- S3 배포가 성공하면 CloudFront 배포 `E32Z5UQBMO5UFL`의 캐시를 무효화합니다.
- 모든 경로(`/*`)를 대상으로 최신 정적 파일이 즉시 제공되도록 합니다.

## How It Works
```mermaid
flowchart LR
    A[Build] --> B[Deploy to S3]
    B --> C[Create CloudFront invalidation]
    C --> D[Serve updated assets]
```

## Testing
- `git diff --check`
- YAML LSP diagnostics
- 실제 AWS invalidation 실행은 GitHub Actions 배포 CI에서 확인이 필요합니다.

## Appendix: assumed role 권한 추가
GitHub Actions가 assume하는 `${{ vars.AWS_ROLE_ARN }}` 역할에 아래 인라인 정책 또는 동등한 관리형 정책을 연결합니다.

IAM 콘솔에서 **Roles → 해당 역할 → Add permissions → Create inline policy → JSON**으로 이동한 뒤 아래 정책을 적용합니다.

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": "cloudfront:CreateInvalidation",
      "Resource": "arn:aws:cloudfront::590662143928:distribution/E32Z5UQBMO5UFL"
    }
  ]
}
```
