### PR TITLE
feat: 리쿠르팅 일정 모델 마이그레이션

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,11 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Check GraphQL schema compatibility
+      - name: Validate approved breaking GraphQL cutover (forced dry-run)
         if: github.event_name == 'release'
-        run: pnpm --dir studio exec sanity graphql deploy --dry-run
+        run: >-
+          pnpm --dir studio exec sanity graphql deploy --dry-run --force
+          --dataset production
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Check GraphQL schema compatibility
         if: github.event_name == 'release'
         run: pnpm --dir studio exec sanity graphql deploy --dry-run
@@ -69,12 +75,6 @@ jobs:
         run: pnpm --dir studio exec sanity graphql deploy --force
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Typecheck
-        run: pnpm typecheck
 
       - name: Clean Gatsby build
         run: pnpm clean

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,12 @@ jobs:
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
 
+      - name: Deploy GraphQL API
+        if: github.event_name == 'release'
+        run: pnpm --dir studio exec sanity graphql deploy --force
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+
       - name: Lint
         run: pnpm lint
 
@@ -101,12 +107,6 @@ jobs:
 
       - name: Deploy to S3
         run: pnpm deploy
-
-      - name: Deploy GraphQL API
-        if: github.event_name == 'release'
-        run: pnpm --dir studio exec sanity graphql deploy --force
-        env:
-          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
 
       - name: Deploy Sanity Studio
         if: github.event_name == 'release'

--- a/docs/RS-MIG-01.md
+++ b/docs/RS-MIG-01.md
@@ -116,7 +116,15 @@ pnpm --dir studio exec sanity schemas deploy --workspace default
 pnpm --dir studio exec sanity deploy --yes
 ```
 
-`schemas deploy`는 dry-run flag가 없는 설치 버전의 schema-store write 명령이므로 반드시 별도 승인 후 실행한다. GraphQL API 정의를 이번 릴리스에서 바꾸지 않는다면 GraphQL deploy는 생략한다. 바뀐다면 먼저 다음 검증을 하고 breaking-change 승인 후 별도 배포한다.
+`schemas deploy`는 dry-run flag가 없는 설치 버전의 schema-store write 명령이므로 반드시 별도 승인 후 실행한다. GraphQL API 호환성 dry-run과 실제 GraphQL deploy는 release workflow가 담당한다. release에서는 다음 순서를 지킨다.
+
+1. GraphQL compatibility dry-run
+2. `sanity graphql deploy --force`
+3. lint/typecheck/환경 파일 생성/Gatsby build
+4. S3 deploy
+5. Studio deploy
+
+release workflow의 GraphQL/Studio deploy 단계는 모두 `release` event에만 실행된다. `repository_dispatch` (`sanity-content-update`)는 두 deploy를 시도하지 않으므로, cutover maintenance gate에서는 GraphQL dry-run부터 S3/Studio 완료까지 content-update dispatch와 editor write를 멈추고 release 완료를 확인한 뒤 재개한다. build가 실패하면 normal step failure로 S3와 Studio 단계도 실행되지 않는다. 호환성 확인만 별도로 하려면 다음 read-only dry-run을 사용한다.
 
 ```bash
 pnpm --dir studio exec sanity graphql deploy \
@@ -167,13 +175,13 @@ curl --fail --silent --show-error \
   http://127.0.0.1:9000/recruiting/<verified-department-path>/ >/dev/null
 ```
 
-승인된 deploy command는 기존 repository 절차를 사용한다.
+승인된 release deploy는 기존 GitHub Actions workflow를 사용한다. workflow는 GraphQL compatibility dry-run과 실제 GraphQL deploy를 먼저 끝낸 뒤 checks/env/Gatsby build를 실행하고, build 성공 시에만 S3를 deploy한 다음 Studio를 deploy한다. S3 단계의 기존 command는 다음과 같다.
 
 ```bash
 pnpm deploy
 ```
 
-배포 후 production page에서 모집 일정/지원 절차/individual override를 확인하고, Sanity에서도 exact ID를 read-only query한다. 실패하면 cleanup을 실행하지 않고 previous Gatsby release로 되돌린다.
+`repository_dispatch` content-update run은 GraphQL/Studio deploy 없이 checks/build/S3만 수행하므로, cutover 중에는 section 4의 maintenance gate로 dispatch를 멈춘다. 배포 후 production page에서 모집 일정/지원 절차/individual override를 확인하고, Sanity에서도 exact ID를 read-only query한다. GraphQL deploy 후 build가 실패하면 S3/Studio와 cleanup을 실행하지 않고 previous Gatsby release로 수동 reconcile/rollback한다.
 
 ## 7. release 후 cleanup
 

--- a/docs/RS-MIG-01.md
+++ b/docs/RS-MIG-01.md
@@ -7,7 +7,7 @@
 - 프로젝트: `f877vcud`, production dataset: `production`.
 - 검증된 도구 버전: Studio package `sanity@6.9.2`, 설치된 CLI `@sanity/cli@7.18.0`, migration API: `sanity/migrate`. 버전과 help gate를 실행 결과에 보관하고, 값이 다르면 중지한다.
 - migration ID는 `rs-mig-01-backfill`과 `rs-mig-01-cleanup`이다. `sanity migrations`는 검증된 CLI 7.18.0에서 지원되는 명령이다.
-- backfill은 legacy O 문서 하나만 patch한다. legacy X 문서와 legacy department 필드/문서는 보존한다. 새 target payload가 있는 O 문서를 다시 만들지 않는다.
+- backfill은 legacy O 문서 하나만 patch한다. baseline에서 생성된 선택 O/X가 `isActive`를 생략한 경우를 허용하되, O만 `true`로 보강하고 X는 생략 또는 `false`로 유지한다. 선택 X의 `true`/malformed 값과 unrelated schedule의 누락/비활성 외 상태는 abort한다. legacy X 문서와 legacy department 필드/문서는 보존한다. 새 target payload가 있는 O 문서를 다시 만들지 않는다.
 - cleanup은 release 후 별도 승인으로만 실행한다. 정확히 검증된 X ID 삭제, backfill에서 처리한 정확한 department ID의 `applyProcedure` unset, 선택한 O 문서의 legacy root `formSchedule`/`procedure` unset만 허용한다.
 - 이 migration은 새 스키마를 배포하거나 Gatsby/UI 동작을 바꾸지 않는다. S3 배포와 production 쓰기는 운영자 책임이다.
 
@@ -15,7 +15,7 @@
 
 - `studio/migrations/rs-mig-01-backfill/index.ts`: 전체 입력을 먼저 읽고 preflight를 통과한 뒤 O 문서에 한 번의 patch를 만든다.
 - `studio/migrations/rs-mig-01-backfill/lib.ts`: pair/mode/reference/date/procedure/target/allowlist 검증과 deterministic payload 생성.
-- `studio/migrations/rs-mig-01-backfill/check.ts`: dependency-free 순수 check. individual override, 재실행 no-op, O/X 충돌 abort를 검증한다.
+- `studio/migrations/rs-mig-01-backfill/check.ts`: dependency-free 순수 check. individual override, O/X `isActive` 생략 호환, 재실행 no-op, partial cleanup recovery, O/X 충돌 abort를 검증한다.
 - `studio/migrations/rs-mig-01-cleanup/index.ts`: backfill과 분리된 cleanup migration. 파일 안의 `manifest`는 빈 template이므로 운영자가 성공한 backfill report의 ID만 채워야 한다. 이 파일에 production ID를 커밋하지 않는다.
 
 preflight는 async iterable migration의 첫 yield 전에 모든 `recruitingSchedule`/`department` 문서를 수집한다. 관련 문서 ID가 `drafts.`로 시작하면 선택 전에 즉시 abort한다. 따라서 preflight가 실패하면 mutation yield가 없어 write가 발생하지 않는다. Sanity runner는 mutation을 최대 256KB 요청 batch로 나누고 기본 동시성 6으로 제출한다. 원자성은 각 제출 batch/transaction 단위뿐이며 일부 batch만 commit되거나 실패/unknown outcome이 섞일 수 있다. `UnknownTransactionOutcome` 또는 부분 실패가 보이면 all-or-nothing으로 가정하거나 blind retry하지 말고 즉시 중지한다. fresh export와 inventory를 만들고 exact ID/field를 reconcile한 뒤 reviewer가 확인하고, idempotent migration을 검토 후 다시 실행한다.
@@ -51,7 +51,7 @@ shasum -a 256 "$RS_EXPORT"
 tar -tzf "$RS_EXPORT" | head
 ```
 
-export는 `/tmp` 등 repository 밖에 둔다. `.env`, token, Sanity secret을 export/archive/git에 넣지 않는다. `--no-drafts` export는 fixture/staging dry-run용이며, 실제 live migration은 CLI가 dataset export endpoint에서 읽으므로 write 전에 아래 live inventory도 다시 확인한다.
+export는 `/tmp` 등 repository 밖에 둔다. `.env`, token, Sanity secret을 export/archive/git에 넣지 않는다. 설치된 CLI는 `--from-export`와 execution 자체를 지원하지만, RS-MIG-01 정책은 export-backed 실행을 dry-run으로만 허용한다. `--no-drafts` export는 fixture/staging dry-run용이며, 실제 live migration은 CLI가 dataset export endpoint에서 읽으므로 write 전에 아래 live inventory도 다시 확인한다.
 
 승인된 별도 staging dataset에서만 export를 import할 수 있다. production dataset을 target으로 쓰지 않는다.
 
@@ -71,7 +71,7 @@ pnpm --dir studio exec sanity documents query \
   > /tmp/rs-mig-01-inventory.json
 ```
 
-export 또는 staging에서 먼저 읽기 전용 dry-run을 한다. `--from-export`는 설치된 CLI help상 dry-run에만 지원되므로 이 명령에는 `--no-dry-run`을 붙이지 않는다. 기본값이 dry mode다.
+export 또는 staging에서 먼저 읽기 전용 dry-run을 한다. 설치된 CLI help는 `--from-export`를 execution에도 허용하지만, RS-MIG-01 운영 정책상 export-backed 실행에는 `--no-dry-run`을 붙이지 않는다. 기본값이 dry mode다.
 
 ```bash
 pnpm --dir studio exec sanity migrations run rs-mig-01-backfill \
@@ -90,7 +90,7 @@ pnpm --dir studio exec sanity migrations run rs-mig-01-backfill \
 
 1. title이 `... - 과제 O`/`... - 과제 X`인 legacy 문서가 각각 정확히 하나가 아님.
 2. 두 title의 cycle prefix가 다름.
-3. 다른 schedule의 `isActive`가 `false`가 아니거나 새 target field를 가짐 (누락도 abort).
+3. 선택 O/X를 제외한 unrelated schedule의 `isActive`가 `false`가 아니거나 새 target field를 가짐 (누락도 abort). 선택 X는 `isActive` 생략 또는 `false`만 허용하며, 선택 O는 생략을 허용하고 backfill에서 `true`로 설정한다.
 4. O/X의 form date가 `YYYY-MM-DD`가 아니거나 실제 날짜가 아니고, procedure가 없거나 비어 있거나 step/schedule이 불완전함.
 5. recruiting department의 legacy mode가 정확히 하나가 아님. mode 충돌/누락, individual detail 누락도 abort.
 6. department reference/ID가 중복·누락이거나 target detail에 같은 department가 둘 이상 매핑됨.
@@ -118,11 +118,13 @@ pnpm --dir studio exec sanity deploy --yes
 
 `schemas deploy`는 dry-run flag가 없는 설치 버전의 schema-store write 명령이므로 반드시 별도 승인 후 실행한다. GraphQL API 호환성 dry-run과 실제 GraphQL deploy는 release workflow가 담당한다. release에서는 다음 순서를 지킨다.
 
-1. GraphQL compatibility dry-run
-2. `sanity graphql deploy --force`
-3. lint/typecheck/환경 파일 생성/Gatsby build
-4. S3 deploy
-5. Studio deploy
+1. lint
+2. typecheck
+3. GraphQL compatibility dry-run
+4. `sanity graphql deploy --force`
+5. 환경 파일 생성/Gatsby build
+6. S3 deploy
+7. Studio deploy
 
 release workflow의 GraphQL/Studio deploy 단계는 모두 `release` event에만 실행된다. `repository_dispatch` (`sanity-content-update`)는 두 deploy를 시도하지 않으므로, cutover maintenance gate에서는 GraphQL dry-run부터 S3/Studio 완료까지 content-update dispatch와 editor write를 멈추고 release 완료를 확인한 뒤 재개한다. build가 실패하면 normal step failure로 S3와 Studio 단계도 실행되지 않는다. 호환성 확인만 별도로 하려면 다음 read-only dry-run을 사용한다.
 
@@ -175,17 +177,17 @@ curl --fail --silent --show-error \
   http://127.0.0.1:9000/recruiting/<verified-department-path>/ >/dev/null
 ```
 
-승인된 release deploy는 기존 GitHub Actions workflow를 사용한다. workflow는 GraphQL compatibility dry-run과 실제 GraphQL deploy를 먼저 끝낸 뒤 checks/env/Gatsby build를 실행하고, build 성공 시에만 S3를 deploy한 다음 Studio를 deploy한다. S3 단계의 기존 command는 다음과 같다.
+승인된 release deploy는 기존 GitHub Actions workflow를 사용한다. workflow는 lint/typecheck를 먼저 끝낸 뒤 GraphQL compatibility dry-run과 실제 GraphQL deploy를 실행하고, checks/env/Gatsby build 성공 시에만 S3를 deploy한 다음 Studio를 deploy한다. 자동 rollback은 수행하지 않는다. S3 단계의 기존 command는 다음과 같다.
 
 ```bash
 pnpm deploy
 ```
 
-`repository_dispatch` content-update run은 GraphQL/Studio deploy 없이 checks/build/S3만 수행하므로, cutover 중에는 section 4의 maintenance gate로 dispatch를 멈춘다. 배포 후 production page에서 모집 일정/지원 절차/individual override를 확인하고, Sanity에서도 exact ID를 read-only query한다. GraphQL deploy 후 build가 실패하면 S3/Studio와 cleanup을 실행하지 않고 previous Gatsby release로 수동 reconcile/rollback한다.
+`repository_dispatch` content-update run은 GraphQL/Studio deploy 없이 checks/build/S3만 수행하므로, cutover 중에는 section 4의 maintenance gate로 dispatch를 멈춘다. 배포 후 production page에서 모집 일정/지원 절차/individual override를 확인하고, Sanity에서도 exact ID를 read-only query한다. GraphQL deploy 후 build가 실패하면 S3/Studio와 cleanup을 실행하지 않고 previous Gatsby release로 수동 reconcile한다. 자동 rollback은 없다.
 
 ## 7. release 후 cleanup
 
-cleanup은 live page 확인, previous export 보관, operator의 명시적 승인 이후에만 실행한다. cleanup file의 `manifest`에 성공한 backfill report의 다음 값만 채운다.
+cleanup은 live page 확인, previous export 보관, operator의 명시적 승인 이후에만 실행한다. cleanup 시작부터 cleanup write 직후의 fresh inventory/query와 final verification이 끝날 때까지 editor/content update freeze를 유지한다. cleanup file의 `manifest`에 성공한 backfill report의 다음 값만 채운다.
 
 ```ts
 const manifest: CleanupManifest = {
@@ -207,13 +209,17 @@ department”가 아니라 backfill이 mode를 확인하고 target에 실제로 
 release가 legacy root를 더 이상 읽지 않는 것을 확인하고 별도 승인을 받은
 경우에만 `true`로 바꾼다.
 
-먼저 cleanup 직전 fresh export를 만들고 dry-run한다.
+먼저 cleanup 직전 fresh export와 inventory/query를 만들고 dry-run한다.
 
 ```bash
 export RS_CLEANUP_EXPORT="/tmp/rs-mig-01-pre-cleanup-$(date +%Y%m%d-%H%M%S).tar.gz"
 pnpm --dir studio exec sanity datasets export production "$RS_CLEANUP_EXPORT" \
   --project-id f877vcud --no-assets --no-drafts --raw
 shasum -a 256 "$RS_CLEANUP_EXPORT"
+pnpm --dir studio exec sanity documents query \
+  '*[_type in ["recruitingSchedule", "department"]] | order(_type asc, _id asc){_id, _type, title, isActive, applyProcedure, formSchedule, procedure, withAssignment, withoutAssignment}' \
+  --project-id f877vcud --dataset production --api-version 2025-08-15 \
+  > /tmp/rs-mig-01-pre-cleanup-inventory.json
 
 pnpm --dir studio exec sanity migrations run rs-mig-01-cleanup \
   --from-export="$RS_CLEANUP_EXPORT" --project=f877vcud --dataset=production \
@@ -222,14 +228,18 @@ pnpm --dir studio exec sanity migrations run rs-mig-01-cleanup \
 
 첫 cleanup dry-run에서 허용되는 출력은 정확한 `legacyXId` 하나의 delete, allowlist department들의 `applyProcedure` unset, `removeLegacyRoots=true`일 때만 O root 두 field unset이다. 새 `withAssignment`/`withoutAssignment`와 O의 `isActive`는 출력에 없어야 한다. ID/allowlist mismatch, O/X state mismatch, 다른 X 존재, department 누락이면 abort한다.
 
-operator가 dry-run과 live verification을 확인한 후에만 write한다.
+operator가 dry-run과 live verification을 확인하고, freeze를 유지한 채 **no-dry-run 직전에 fresh inventory/query를 한 번 더 실행**한 후에만 write한다. 이 native migration에는 revision guard를 추가하지 않는다.
 
 ```bash
+pnpm --dir studio exec sanity documents query \
+  '*[_type in ["recruitingSchedule", "department"]] | order(_type asc, _id asc){_id, _type, title, isActive, applyProcedure, formSchedule, procedure, withAssignment, withoutAssignment}' \
+  --project-id f877vcud --dataset production --api-version 2025-08-15 \
+  > /tmp/rs-mig-01-immediately-before-cleanup-write.json
 pnpm --dir studio exec sanity migrations run rs-mig-01-cleanup \
   --project=f877vcud --dataset=production --progress --no-dry-run
 ```
 
-write 후 fresh export를 다시 만들고 같은 manifest로 cleanup dry-run을 다시 실행한다. exit 0이며 mutation 출력이 없어야 한다. 이것이 두 번째 cleanup no-op 증거다. backfill도 enriched O export에서 두 번째 dry-run을 실행해 mutation 출력이 없는지 확인한다.
+write 후 freeze를 유지한 채 fresh export와 inventory/query를 다시 만들고 같은 manifest로 cleanup dry-run을 다시 실행한다. exit 0이며 mutation 출력이 없어야 한다. 이것이 두 번째 cleanup no-op 증거다. 최종 verification을 완료하고 reviewer/operator가 확인한 뒤에만 editor/content update freeze를 해제한다. backfill도 enriched O export에서 두 번째 dry-run을 실행해 mutation 출력이 없는지 확인한다.
 
 ## 8. rollback
 

--- a/docs/RS-MIG-01.md
+++ b/docs/RS-MIG-01.md
@@ -120,18 +120,24 @@ pnpm --dir studio exec sanity deploy --yes
 
 1. lint
 2. typecheck
-3. GraphQL compatibility dry-run
-4. `sanity graphql deploy --force`
+3. 승인된 breaking cutover의 forced GraphQL dry-run (검증만)
+4. `sanity graphql deploy --force` (실제 배포)
 5. 환경 파일 생성/Gatsby build
 6. S3 deploy
 7. Studio deploy
 
-release workflow의 GraphQL/Studio deploy 단계는 모두 `release` event에만 실행된다. `repository_dispatch` (`sanity-content-update`)는 두 deploy를 시도하지 않으므로, cutover maintenance gate에서는 GraphQL dry-run부터 S3/Studio 완료까지 content-update dispatch와 editor write를 멈추고 release 완료를 확인한 뒤 재개한다. build가 실패하면 normal step failure로 S3와 Studio 단계도 실행되지 않는다. 호환성 확인만 별도로 하려면 다음 read-only dry-run을 사용한다.
+PR #158과 이 runbook은 다음 16개 legacy GraphQL 필드 제거를 의도된 breaking cutover로 명시적으로 승인한다: `Department.applyProcedure`, `RecruitingScheduleContent.scheduleWithoutAssignment`, `RecruitingScheduleContent.scheduleWithAssignment`, `RecruitingScheduleContent.individualSchedule`, `RecruitingSchedule.formSchedule`, `RecruitingSchedule.procedure`, `DepartmentFilter.applyProcedure`, `RecruitingScheduleContentFilter.scheduleWithoutAssignment`, `RecruitingScheduleContentFilter.scheduleWithAssignment`, `RecruitingScheduleContentFilter.individualSchedule`, `DepartmentSorting.applyProcedure`, `RecruitingScheduleContentSorting.scheduleWithoutAssignment`, `RecruitingScheduleContentSorting.scheduleWithAssignment`, `RecruitingScheduleContentSorting.individualSchedule`, `RecruitingScheduleFilter.formSchedule`, `RecruitingScheduleSorting.formSchedule`. production unforced dry-run에서 확인된 예상 GraphQL additions는 정확히 다음 6개다: `RecruitingScheduleFilter.isActive`, `RecruitingScheduleFilter.withAssignment`, `RecruitingScheduleFilter.withoutAssignment`, `RecruitingScheduleSorting.isActive`, `RecruitingScheduleSorting.withAssignment`, `RecruitingScheduleSorting.withoutAssignment`. 이 16개 removal과 6개 addition 외에 어떤 GraphQL addition 또는 removal이라도 발견되면 release를 중지하고 수동 검토한다.
+
+release workflow의 GraphQL/Studio deploy 단계는 모두 `release` event에만 실행된다. `repository_dispatch` (`sanity-content-update`)는 두 deploy를 시도하지 않으므로, cutover maintenance gate에서는 GraphQL dry-run부터 S3/Studio 완료까지 content-update dispatch와 editor write를 멈추고 release 완료를 확인한 뒤 재개한다. build가 실패하면 normal step failure로 S3와 Studio 단계도 실행되지 않는다. 강제 dry-run은 schema extraction/remote validation만 수행하며 deploy하지 않고, 실제 `sanity graphql deploy --force` 단계와 분리되어 바로 뒤에 실행된다.
+
+강제 dry-run은 diff 상세를 출력하지 않을 수 있다. 그러므로 operator는 먼저 다음 unforced read-only dry-run의 전체 출력과 exit code를 기록하고, 정확히 위의 승인된 16개 제거와 optional additions만 비교한 뒤 forced dry-run 및 실제 deploy를 실행한다. unforced 결과가 known diff와 다르면 중지하고 수동 검토한다.
 
 ```bash
 pnpm --dir studio exec sanity graphql deploy \
   --dry-run --dataset production
 ```
+
+이 unforced 명령은 승인된 breaking removals 때문에 현재 nonzero가 예상된다. 반대로 release workflow의 forced dry-run은 extraction/remote validation이 성공할 때만 zero로 끝나며, 실패하면 실제 deploy로 진행하지 않는다.
 
 ## 5. merge window backfill write
 

--- a/docs/RS-MIG-01.md
+++ b/docs/RS-MIG-01.md
@@ -1,0 +1,288 @@
+# RS-MIG-01 운영 런북
+
+> 이 문서는 `refactor/recruit-schedule`의 S2 migration artifact를 운영자가 실행하기 위한 문서다. 이 에이전트는 production migration을 실행하지 않았다. 아래의 `--no-dry-run` 명령은 명시적인 운영자 승인과 점검 창에서만 실행한다.
+
+## 0. 범위와 불변 조건
+
+- 프로젝트: `f877vcud`, production dataset: `production`.
+- 검증된 도구 버전: Studio package `sanity@6.9.2`, 설치된 CLI `@sanity/cli@7.18.0`, migration API: `sanity/migrate`. 버전과 help gate를 실행 결과에 보관하고, 값이 다르면 중지한다.
+- migration ID는 `rs-mig-01-backfill`과 `rs-mig-01-cleanup`이다. `sanity migrations`는 검증된 CLI 7.18.0에서 지원되는 명령이다.
+- backfill은 legacy O 문서 하나만 patch한다. legacy X 문서와 legacy department 필드/문서는 보존한다. 새 target payload가 있는 O 문서를 다시 만들지 않는다.
+- cleanup은 release 후 별도 승인으로만 실행한다. 정확히 검증된 X ID 삭제, backfill에서 처리한 정확한 department ID의 `applyProcedure` unset, 선택한 O 문서의 legacy root `formSchedule`/`procedure` unset만 허용한다.
+- 이 migration은 새 스키마를 배포하거나 Gatsby/UI 동작을 바꾸지 않는다. S3 배포와 production 쓰기는 운영자 책임이다.
+
+## 1. 파일과 안전장치
+
+- `studio/migrations/rs-mig-01-backfill/index.ts`: 전체 입력을 먼저 읽고 preflight를 통과한 뒤 O 문서에 한 번의 patch를 만든다.
+- `studio/migrations/rs-mig-01-backfill/lib.ts`: pair/mode/reference/date/procedure/target/allowlist 검증과 deterministic payload 생성.
+- `studio/migrations/rs-mig-01-backfill/check.ts`: dependency-free 순수 check. individual override, 재실행 no-op, O/X 충돌 abort를 검증한다.
+- `studio/migrations/rs-mig-01-cleanup/index.ts`: backfill과 분리된 cleanup migration. 파일 안의 `manifest`는 빈 template이므로 운영자가 성공한 backfill report의 ID만 채워야 한다. 이 파일에 production ID를 커밋하지 않는다.
+
+preflight는 async iterable migration의 첫 yield 전에 모든 `recruitingSchedule`/`department` 문서를 수집한다. 관련 문서 ID가 `drafts.`로 시작하면 선택 전에 즉시 abort한다. 따라서 preflight가 실패하면 mutation yield가 없어 write가 발생하지 않는다. Sanity runner는 mutation을 최대 256KB 요청 batch로 나누고 기본 동시성 6으로 제출한다. 원자성은 각 제출 batch/transaction 단위뿐이며 일부 batch만 commit되거나 실패/unknown outcome이 섞일 수 있다. `UnknownTransactionOutcome` 또는 부분 실패가 보이면 all-or-nothing으로 가정하거나 blind retry하지 말고 즉시 중지한다. fresh export와 inventory를 만들고 exact ID/field를 reconcile한 뒤 reviewer가 확인하고, idempotent migration을 검토 후 다시 실행한다.
+
+## 2. 인증과 production export (repo 밖)
+
+Sanity CLI 인증은 `.env`를 읽거나 복사하지 말고 operator 계정으로 수행한다. export/import 또는 migration 전에 repository 밖에서 아래 gate를 실행한다. 버전이 `sanity 6.9.2`/`@sanity/cli 7.18.0`과 다르거나, help에 필요한 문법이 없으면 실행하지 않는다. 이 gate는 import하지 않는다.
+
+```bash
+cd /Users/hyominkoo/Projects/yourssu.com
+set -eu
+pnpm --dir studio exec sanity versions | tee /tmp/rs-mig-01-sanity-versions.txt
+grep -F '@sanity/cli (global)  7.18.0' /tmp/rs-mig-01-sanity-versions.txt
+grep -F 'sanity                 6.9.2' /tmp/rs-mig-01-sanity-versions.txt
+pnpm --dir studio exec sanity --version | grep -F '@sanity/cli/7.18.0'
+pnpm --dir studio exec sanity migrations run --help | grep -F -- '--from-export'
+pnpm --dir studio exec sanity migrations run --help | grep -F -- '--no-dry-run'
+pnpm --dir studio exec sanity datasets import --help | grep -F -- '--missing'
+if pnpm --dir studio exec sanity datasets import --help | grep -F -- '--no-assets'; then
+  echo 'unsupported --no-assets appeared in import help' >&2
+  exit 1
+fi
+```
+
+```bash
+cd /Users/hyominkoo/Projects/yourssu.com
+pnpm --dir studio exec sanity login
+
+export RS_EXPORT="/tmp/rs-mig-01-production-$(date +%Y%m%d-%H%M%S).tar.gz"
+pnpm --dir studio exec sanity datasets export production "$RS_EXPORT" \
+  --project-id f877vcud --no-assets --no-drafts --raw
+shasum -a 256 "$RS_EXPORT"
+tar -tzf "$RS_EXPORT" | head
+```
+
+export는 `/tmp` 등 repository 밖에 둔다. `.env`, token, Sanity secret을 export/archive/git에 넣지 않는다. `--no-drafts` export는 fixture/staging dry-run용이며, 실제 live migration은 CLI가 dataset export endpoint에서 읽으므로 write 전에 아래 live inventory도 다시 확인한다.
+
+승인된 별도 staging dataset에서만 export를 import할 수 있다. production dataset을 target으로 쓰지 않는다.
+
+```bash
+pnpm --dir studio exec sanity datasets import "$RS_EXPORT" staging \
+  --project-id f877vcud --missing
+```
+
+## 3. read-only inventory와 preflight
+
+먼저 production을 읽어 정확한 ID/title, 활성 상태, legacy mode, 새 target payload를 보관한다. 이 명령은 query만 수행한다.
+
+```bash
+pnpm --dir studio exec sanity documents query \
+  '*[_type in ["recruitingSchedule", "department"]] | order(_type asc, _id asc){_id, _type, title, isActive, basicInformation{name, isRecruiting}, applyProcedure, formSchedule, procedure, withAssignment, withoutAssignment}' \
+  --project-id f877vcud --dataset production --api-version 2025-08-15 \
+  > /tmp/rs-mig-01-inventory.json
+```
+
+export 또는 staging에서 먼저 읽기 전용 dry-run을 한다. `--from-export`는 설치된 CLI help상 dry-run에만 지원되므로 이 명령에는 `--no-dry-run`을 붙이지 않는다. 기본값이 dry mode다.
+
+```bash
+pnpm --dir studio exec sanity migrations run rs-mig-01-backfill \
+  --from-export="$RS_EXPORT" --project=f877vcud --dataset=production \
+  --no-confirm --no-progress
+```
+
+staging dataset을 준비했다면 export 대신 staging API를 읽을 수 있다.
+
+```bash
+pnpm --dir studio exec sanity migrations run rs-mig-01-backfill \
+  --project=f877vcud --dataset=staging --no-confirm --no-progress
+```
+
+성공한 backfill dry-run은 `schedule-o` 하나에 `isActive`, `withAssignment`, `withoutAssignment` patch만 출력해야 한다. 다음은 반드시 abort되어야 한다.
+
+1. title이 `... - 과제 O`/`... - 과제 X`인 legacy 문서가 각각 정확히 하나가 아님.
+2. 두 title의 cycle prefix가 다름.
+3. 다른 schedule의 `isActive`가 `false`가 아니거나 새 target field를 가짐 (누락도 abort).
+4. O/X의 form date가 `YYYY-MM-DD`가 아니거나 실제 날짜가 아니고, procedure가 없거나 비어 있거나 step/schedule이 불완전함.
+5. recruiting department의 legacy mode가 정확히 하나가 아님. mode 충돌/누락, individual detail 누락도 abort.
+6. department reference/ID가 중복·누락이거나 target detail에 같은 department가 둘 이상 매핑됨.
+7. O에 일부 target만 있거나 기존 target payload가 새로 계산한 payload와 다름.
+8. inventory에 나온 예상 밖 active/target state.
+
+오류에는 관련 schedule ID/title 및 department ID/name inventory가 포함된다. 실패하면 report를 보관하고 데이터를 수정한 뒤 처음부터 새 export와 dry-run을 만든다.
+
+## 4. schema/content-update maintenance gate
+
+migration 전에 merge 대상 코드와 Studio schema를 고정하고, production content editor의 일정/부서 편집을 중지한다. 먼저 local schema check와 Studio deploy preview를 실행한다.
+
+```bash
+pnpm --dir studio exec sanity schemas validate \
+  --workspace default --level error
+pnpm --dir studio exec sanity deploy --dry-run
+```
+
+이번 artifact는 schema shape를 새 모델로 바꾸는 S1과 함께 릴리스되는 전제다. 실제 Studio/schema 배포가 필요한 merge window에서만 다음을 실행한다.
+
+```bash
+pnpm --dir studio exec sanity schemas deploy --workspace default
+pnpm --dir studio exec sanity deploy --yes
+```
+
+`schemas deploy`는 dry-run flag가 없는 설치 버전의 schema-store write 명령이므로 반드시 별도 승인 후 실행한다. GraphQL API 정의를 이번 릴리스에서 바꾸지 않는다면 GraphQL deploy는 생략한다. 바뀐다면 먼저 다음 검증을 하고 breaking-change 승인 후 별도 배포한다.
+
+```bash
+pnpm --dir studio exec sanity graphql deploy \
+  --dry-run --dataset production
+```
+
+## 5. merge window backfill write
+
+1. 직전 production inventory와 export hash를 저장한다.
+2. maintenance gate에서 editor write를 멈춘다.
+3. 위의 live read-only inventory와 export 기반 dry-run이 같은 O/X ID/title 및 department allowlist를 보고하는지 확인한다.
+4. reviewer와 operator가 dry-run의 **유일한 write 대상이 legacy O ID**임을 확인한다.
+5. interactive confirmation을 유지한 채 다음 write를 한 번 실행한다.
+
+```bash
+pnpm --dir studio exec sanity migrations run rs-mig-01-backfill \
+  --project=f877vcud --dataset=production --progress
+```
+
+위 명령은 기본 dry mode이므로 실제 write가 필요한 경우에만 명시적으로 다음을 추가한다.
+
+```bash
+pnpm --dir studio exec sanity migrations run rs-mig-01-backfill \
+  --project=f877vcud --dataset=production --progress --no-dry-run
+```
+
+`--no-dry-run`은 이 문서의 operator-only command다. 두 번째 명령 직전에 operator가 confirmation prompt와 target dataset을 재확인한다. 이 migration은 새 target fields와 `isActive`만 patch하므로 기존 title, legacy root `formSchedule`/`procedure`, X 문서, department 문서를 삭제하거나 수정하지 않는다.
+
+write 직후 read-only query를 다시 실행한다. O에는 target 두 개와 `isActive: true`, X에는 기존 title/legacy payload가 남아 있어야 한다. 결과가 성공이거나 이미 같은 payload인 경우 backfill dry-run을 다시 실행하면 mutation 출력 없이 exit 0이어야 한다.
+
+네트워크 timeout/unknown transaction outcome이면 retry 전에 export와 query로 O를 확인한다. O가 기대 payload와 완전히 같으면 no-op으로 간주하고, 다르면 즉시 중지하여 reviewer에게 보고한다. 임의의 `--replace`나 다른 문서 patch를 사용하지 않는다.
+
+## 6. Gatsby merge/deploy와 live 확인
+
+backfill이 끝난 뒤에만 Gatsby 변경을 merge하고, release artifact를 만든다.
+
+```bash
+pnpm build
+find public/recruiting -mindepth 2 -maxdepth 2 -name index.html -print | sort
+pnpm serve --host 127.0.0.1 --port 9000
+```
+
+별도 shell에서 대표 홈/모집/부서 URL을 확인한다. 실제 department path는 위 `find` 결과와 production inventory의 이름으로 operator가 대체한다.
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:9000/ >/dev/null
+curl --fail --silent --show-error \
+  http://127.0.0.1:9000/recruiting/<verified-department-path>/ >/dev/null
+```
+
+승인된 deploy command는 기존 repository 절차를 사용한다.
+
+```bash
+pnpm deploy
+```
+
+배포 후 production page에서 모집 일정/지원 절차/individual override를 확인하고, Sanity에서도 exact ID를 read-only query한다. 실패하면 cleanup을 실행하지 않고 previous Gatsby release로 되돌린다.
+
+## 7. release 후 cleanup
+
+cleanup은 live page 확인, previous export 보관, operator의 명시적 승인 이후에만 실행한다. cleanup file의 `manifest`에 성공한 backfill report의 다음 값만 채운다.
+
+```ts
+const manifest: CleanupManifest = {
+  backfillTargetFingerprint:
+    '<backfill report의 exact O ID/title/new fields fingerprint>',
+  departmentIds: ['<backfill report의 exact department IDs>'],
+  legacyOId: '<backfill report의 exact O ID>',
+  legacyXId: '<backfill report의 exact X ID>',
+  removeLegacyRoots: false,
+};
+```
+
+이 변경은 production ID template이므로 commit하지 않는다.
+`backfillTargetFingerprint`는 backfill report가 계산한 O의 exact
+ID/title/`withAssignment`/`withoutAssignment` payload fingerprint다. 첫 cleanup과
+X 삭제 후 rerun 모두 이 fingerprint를 비교한다. `departmentIds`는 “모든
+department”가 아니라 backfill이 mode를 확인하고 target에 실제로 매핑한 ID의
+정렬 가능한 exact allowlist여야 한다. `removeLegacyRoots`는 기본 `false`다.
+release가 legacy root를 더 이상 읽지 않는 것을 확인하고 별도 승인을 받은
+경우에만 `true`로 바꾼다.
+
+먼저 cleanup 직전 fresh export를 만들고 dry-run한다.
+
+```bash
+export RS_CLEANUP_EXPORT="/tmp/rs-mig-01-pre-cleanup-$(date +%Y%m%d-%H%M%S).tar.gz"
+pnpm --dir studio exec sanity datasets export production "$RS_CLEANUP_EXPORT" \
+  --project-id f877vcud --no-assets --no-drafts --raw
+shasum -a 256 "$RS_CLEANUP_EXPORT"
+
+pnpm --dir studio exec sanity migrations run rs-mig-01-cleanup \
+  --from-export="$RS_CLEANUP_EXPORT" --project=f877vcud --dataset=production \
+  --no-confirm --no-progress
+```
+
+첫 cleanup dry-run에서 허용되는 출력은 정확한 `legacyXId` 하나의 delete, allowlist department들의 `applyProcedure` unset, `removeLegacyRoots=true`일 때만 O root 두 field unset이다. 새 `withAssignment`/`withoutAssignment`와 O의 `isActive`는 출력에 없어야 한다. ID/allowlist mismatch, O/X state mismatch, 다른 X 존재, department 누락이면 abort한다.
+
+operator가 dry-run과 live verification을 확인한 후에만 write한다.
+
+```bash
+pnpm --dir studio exec sanity migrations run rs-mig-01-cleanup \
+  --project=f877vcud --dataset=production --progress --no-dry-run
+```
+
+write 후 fresh export를 다시 만들고 같은 manifest로 cleanup dry-run을 다시 실행한다. exit 0이며 mutation 출력이 없어야 한다. 이것이 두 번째 cleanup no-op 증거다. backfill도 enriched O export에서 두 번째 dry-run을 실행해 mutation 출력이 없는지 확인한다.
+
+## 8. rollback
+
+### Gatsby/Studio release rollback
+
+content cleanup 전이라면 previous Gatsby release artifact를 다시 배포하고 Studio deploy를 previous known-good release로 되돌린다. 새 O target fields와 legacy data가 함께 있으므로 old Gatsby가 legacy data를 다시 읽을 수 있는지 release compatibility를 먼저 확인한다. cleanup 후에는 old release가 삭제된 X/`applyProcedure`/legacy root를 요구할 수 있으므로 content rollback도 함께 해야 한다.
+
+### backfill rollback (cleanup 전)
+
+backfill 직전 export에서 exact O 문서를 추출해, operator가 freeze와 current `_updatedAt`를 확인한 뒤 exact ID 하나만 restore한다. 전체 dataset을 `--replace` import하지 않는다.
+
+```bash
+# RS_EXPORT는 backfill 직전 export, O_ID는 dry-run report의 exact O ID
+export O_ID='<exact legacy O ID>'
+tar -xOzf "$RS_EXPORT" data.ndjson \
+  | jq -c "select(._id == \"$O_ID\")" \
+  > /tmp/rs-mig-01-rollback-o.ndjson
+pnpm --dir studio exec sanity documents create \
+  /tmp/rs-mig-01-rollback-o.ndjson --project-id f877vcud \
+  --dataset production --replace
+```
+
+이 명령은 해당 문서 전체를 export snapshot으로 replace하므로, export 이후 O에 추가된 정상 편집을 덮을 수 있다. 따라서 maintenance freeze, current document diff/`_updatedAt` 확인, operator 승인 없이 실행하지 않는다. backfill은 O 하나만 썼으므로 department rollback은 필요하지 않다.
+
+### cleanup rollback (cleanup 후)
+
+cleanup 직전 `RS_CLEANUP_EXPORT`를 보관했다면, exact X 문서와 backfill allowlist의 exact department snapshot만 staging에서 먼저 검증한다. production에 복원할 때도 `documents create --replace`를 exact IDs에만 사용하고 전체 export import는 금지한다.
+
+```bash
+export X_ID='<manifest의 exact legacy X ID>'
+tar -xOzf "$RS_CLEANUP_EXPORT" data.ndjson \
+  | jq -c "select(._id == \"$X_ID\")" \
+  > /tmp/rs-mig-01-rollback-x.ndjson
+pnpm --dir studio exec sanity documents create \
+  /tmp/rs-mig-01-rollback-x.ndjson --project-id f877vcud \
+  --dataset production --replace
+```
+
+`applyProcedure` 복원은 cleanup 직전 export에서 manifest의 exact department IDs만 추출해 별도 검증한 뒤 exact document replace를 한다. 다른 department를 포함한 파일을 만들지 않는다. snapshot이 현재 문서와 다르면 중지하고 Sanity document history/backup restore 절차로 처리한다.
+
+```bash
+# 예: exact department 하나만 추출한다. <DEPT_ID>를 manifest의 allowlist 값으로 대체한다.
+tar -xOzf "$RS_CLEANUP_EXPORT" data.ndjson \
+  | jq -c 'select(._id == "<DEPT_ID>")' \
+  > /tmp/rs-mig-01-rollback-department.ndjson
+pnpm --dir studio exec sanity documents create \
+  /tmp/rs-mig-01-rollback-department.ndjson --project-id f877vcud \
+  --dataset production --replace
+```
+
+rollback 후 exact ID query, Gatsby build/page check, 그리고 새 release의 schema/content compatibility를 다시 확인한다.
+
+## 9. no-op/실행 금지 체크리스트
+
+- 매 실행 전에 버전/help gate를 통과하고 결과를 operator-local log로 보관한다. 현재 검증값은 `sanity@6.9.2`와 `@sanity/cli@7.18.0`이다.
+- migration runner의 batch는 최대 256KB, 기본 동시성은 6이며 전체 migration
+  all-or-nothing이 아니다. 부분/unknown commit이면 중지 → fresh
+  export/inventory → exact ID/field reconcile → reviewer 확인 → idempotent rerun
+  순서를 지킨다. blind retry하지 않는다.
+- `sanity migrations run`은 기본 dry mode다. read-only/preflight/staging에서는 `--no-dry-run`을 사용하지 않는다.
+- 이 agent는 production migration, schema deploy, dataset import, S3 deploy, secrets export를 실행하지 않았다.
+- migration source/target에 대한 예상 밖 문서가 있으면 선택하거나 자동 비활성화하지 않고 abort한다.
+- cleanup manifest가 빈 template인 상태로는 실행되지 않는다. operator가 exact IDs를 채우고 검증해야 한다.
+- 두 번째 backfill dry-run과 두 번째 cleanup dry-run은 각각 mutation 0건이어야 한다.

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -3,6 +3,7 @@ import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import recruitingSchedule, {
   type RecruitingDepartmentReference,
   type RecruitingScheduleDocument,
+  validateRecruitingSchedule,
 } from './src/utils/recruitingSchedule';
 
 interface QueryResult {
@@ -185,6 +186,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
       .map(({ node }) => node._id)
       .filter((id): id is string => Boolean(id)),
   );
+  validateRecruitingSchedule(schedule, knownDepartmentIds);
   const DescriptionTemplateComponent = path.resolve(
     __dirname,
     'src/templates/DescriptionTemplate.tsx',

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -3,7 +3,6 @@ import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import recruitingSchedule, {
   type RecruitingDepartmentReference,
   type RecruitingScheduleDocument,
-  validateRecruitingSchedule,
 } from './src/utils/recruitingSchedule';
 
 interface QueryResult {
@@ -186,8 +185,6 @@ export const createPages: GatsbyNode['createPages'] = async ({
       .map(({ node }) => node._id)
       .filter((id): id is string => Boolean(id)),
   );
-  validateRecruitingSchedule(schedule, knownDepartmentIds);
-
   const DescriptionTemplateComponent = path.resolve(
     __dirname,
     'src/templates/DescriptionTemplate.tsx',
@@ -207,7 +204,11 @@ export const createPages: GatsbyNode['createPages'] = async ({
       return;
     }
 
-    const recruiting = recruitingSchedule(schedule, department);
+    const recruiting = recruitingSchedule(
+      schedule,
+      department,
+      knownDepartmentIds,
+    );
     const pathName = name.toLowerCase().replaceAll(' ', '_');
 
     createPage({

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,29 +1,15 @@
 import { type GatsbyNode } from 'gatsby';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
-import recruitingSchedule from './src/utils/recruitingSchedule';
+import recruitingSchedule, {
+  type RecruitingDepartmentReference,
+  type RecruitingScheduleDocument,
+  validateRecruitingSchedule,
+} from './src/utils/recruitingSchedule';
 
 interface QueryResult {
   allSanityDepartment: {
     edges: {
-      node: {
-        basicInformation: {
-          name: string;
-          isRecruiting: boolean;
-        };
-        applyProcedure: {
-          scheduleWithoutAssignment: boolean;
-          scheduleWithAssignment: boolean;
-          individualSchedule: boolean;
-          formSchedule: {
-            start: Date;
-            end: Date;
-          };
-          procedure: {
-            step: string;
-            schedule: string;
-          }[];
-        };
-      };
+      node: RecruitingDepartmentReference;
     }[];
   };
   allSanityRecruitingPage: {
@@ -40,35 +26,8 @@ interface QueryResult {
       };
     }[];
   };
-  scheduleWithAssignment: {
-    edges: {
-      node: {
-        title: string;
-        formSchedule: {
-          start: Date;
-          end: Date;
-        };
-        procedure: {
-          step: string;
-          schedule: string;
-        }[];
-      };
-    }[];
-  };
-  scheduleWithoutAssignment: {
-    edges: {
-      node: {
-        title: string;
-        formSchedule: {
-          start: Date;
-          end: Date;
-        };
-        procedure: {
-          step: string;
-          schedule: string;
-        }[];
-      };
-    }[];
+  allSanityRecruitingSchedule: {
+    nodes: RecruitingScheduleDocument[];
   };
 }
 
@@ -99,22 +58,10 @@ export const createPages: GatsbyNode['createPages'] = async ({
       allSanityDepartment {
         edges {
           node {
+            _id
             basicInformation {
               name
               isRecruiting
-            }
-            applyProcedure {
-              scheduleWithoutAssignment
-              scheduleWithAssignment
-              individualSchedule
-              formSchedule {
-                start
-                end
-              }
-              procedure {
-                step
-                schedule
-              }
             }
           }
         }
@@ -136,12 +83,19 @@ export const createPages: GatsbyNode['createPages'] = async ({
           }
         }
       }
-      scheduleWithAssignment: allSanityRecruitingSchedule(
-        filter: { title: { regex: "/과제 O$/" } }
-      ) {
-        edges {
-          node {
-            title
+      allSanityRecruitingSchedule(filter: { isActive: { eq: true } }) {
+        nodes {
+          _id
+          title
+          isActive
+          withAssignment {
+            departments {
+              _id
+              basicInformation {
+                name
+                isRecruiting
+              }
+            }
             formSchedule {
               start
               end
@@ -149,16 +103,33 @@ export const createPages: GatsbyNode['createPages'] = async ({
             procedure {
               step
               schedule
+            }
+            departmentOverrides {
+              department {
+                _id
+                basicInformation {
+                  name
+                  isRecruiting
+                }
+              }
+              formSchedule {
+                start
+                end
+              }
+              procedure {
+                step
+                schedule
+              }
             }
           }
-        }
-      }
-      scheduleWithoutAssignment: allSanityRecruitingSchedule(
-        filter: { title: { regex: "/과제 X$/" } }
-      ) {
-        edges {
-          node {
-            title
+          withoutAssignment {
+            departments {
+              _id
+              basicInformation {
+                name
+                isRecruiting
+              }
+            }
             formSchedule {
               start
               end
@@ -166,6 +137,23 @@ export const createPages: GatsbyNode['createPages'] = async ({
             procedure {
               step
               schedule
+            }
+            departmentOverrides {
+              department {
+                _id
+                basicInformation {
+                  name
+                  isRecruiting
+                }
+              }
+              formSchedule {
+                start
+                end
+              }
+              procedure {
+                step
+                schedule
+              }
             }
           }
         }
@@ -179,6 +167,26 @@ export const createPages: GatsbyNode['createPages'] = async ({
   }
 
   const queryAllSanityData = result.data;
+  if (!queryAllSanityData) {
+    reporter.panicOnBuild(`Sanity query returned no data`);
+    return;
+  }
+
+  const schedules = queryAllSanityData.allSanityRecruitingSchedule.nodes;
+  if (schedules.length !== 1) {
+    reporter.panicOnBuild(
+      `Expected exactly one active recruiting schedule, found ${schedules.length}`,
+    );
+    return;
+  }
+
+  const schedule = schedules[0];
+  const knownDepartmentIds = new Set(
+    queryAllSanityData.allSanityDepartment.edges
+      .map(({ node }) => node._id)
+      .filter((id): id is string => Boolean(id)),
+  );
+  validateRecruitingSchedule(schedule, knownDepartmentIds);
 
   const DescriptionTemplateComponent = path.resolve(
     __dirname,
@@ -186,106 +194,23 @@ export const createPages: GatsbyNode['createPages'] = async ({
   );
 
   const teamList =
-    queryAllSanityData?.allSanityRecruitingPage.nodes[0]?.positions.cards.map(
+    queryAllSanityData.allSanityRecruitingPage.nodes[0]?.positions.cards.map(
       ({ department }) => department.basicInformation,
     ) ?? [];
 
-  const checkRecruitType = (recruitTypeData: {
-    scheduleWithoutAssignment: boolean;
-    scheduleWithAssignment: boolean;
-    individualSchedule: boolean;
-    formSchedule: {
-      start: Date;
-      end: Date;
-    };
-    procedure: {
-      step: string;
-      schedule: string;
-    }[];
-  }): {
-    formSchedule: { start: Date | null; end: Date | null } | null;
-    procedure: { step: string; schedule: string }[] | null;
-  } => {
-    const {
-      scheduleWithoutAssignment,
-      scheduleWithAssignment,
-      individualSchedule,
-      formSchedule,
-      procedure,
-    } = recruitTypeData;
-
-    const recruitingType = {
-      individualSchedule,
-      scheduleWithAssignment,
-      scheduleWithoutAssignment,
-    };
-
-    const scheduleWithAssignmentData =
-      queryAllSanityData?.scheduleWithAssignment?.edges[0]?.node.formSchedule ||
-      null;
-    const scheduleWithoutAssignmentData =
-      queryAllSanityData?.scheduleWithoutAssignment?.edges[0]?.node
-        .formSchedule || null;
-    const scheduleIndividualData = formSchedule || null;
-
-    const recruitingScheduleData = recruitingSchedule({
-      recruitingType,
-      scheduleWithAssignmentData,
-      scheduleWithoutAssignmentData,
-      scheduleIndividualData,
-    });
-
-    if (!recruitingScheduleData) {
-      return {
-        formSchedule: null,
-        procedure: null,
-      };
+  const generateDescriptionPage = (
+    department: RecruitingDepartmentReference,
+  ) => {
+    const name = department.basicInformation?.name;
+    if (!name) {
+      reporter.panicOnBuild('Recruiting department is missing its name');
+      return;
     }
 
-    if (recruitingScheduleData.type === 'individual') {
-      return {
-        formSchedule: recruitingScheduleData.formSchedule,
-        procedure: procedure,
-      };
-    }
-
-    if (recruitingScheduleData.type === 'withAssignment') {
-      return {
-        formSchedule: recruitingScheduleData.formSchedule,
-        procedure:
-          queryAllSanityData?.scheduleWithAssignment?.edges[0]?.node
-            .procedure || [],
-      };
-    }
-
-    if (recruitingScheduleData.type === 'withoutAssignment') {
-      return {
-        formSchedule: recruitingScheduleData.formSchedule,
-        procedure:
-          queryAllSanityData?.scheduleWithoutAssignment?.edges[0]?.node
-            .procedure || [],
-      };
-    }
-
-    return {
-      formSchedule: null,
-      procedure: null,
-    };
-  };
-
-  const generateDescriptionPage = ({
-    name,
-    recruiting,
-  }: {
-    name: string;
-    recruiting: {
-      formSchedule: { start: Date | null; end: Date | null } | null;
-      procedure: { step: string; schedule: string }[] | null;
-    };
-  }) => {
+    const recruiting = recruitingSchedule(schedule, department);
     const pathName = name.toLowerCase().replaceAll(' ', '_');
 
-    const pageOptions = {
+    createPage({
       path: `recruiting/${pathName}`,
       component: DescriptionTemplateComponent,
       context: {
@@ -294,18 +219,12 @@ export const createPages: GatsbyNode['createPages'] = async ({
         formSchedule: recruiting.formSchedule,
         procedure: recruiting.procedure,
       },
-    };
-
-    createPage(pageOptions);
+    });
   };
 
-  queryAllSanityData?.allSanityDepartment.edges.forEach((data) => {
-    if (!data.node.basicInformation.isRecruiting) return;
-
-    generateDescriptionPage({
-      name: data.node.basicInformation.name,
-      recruiting: checkRecruitType(data.node.applyProcedure),
-    });
+  queryAllSanityData.allSanityDepartment.edges.forEach(({ node }) => {
+    if (!node.basicInformation?.isRecruiting) return;
+    generateDescriptionPage(node);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit",
+    "check:recruiting-schedule": "pnpm exec tsx scripts/check-recruitingSchedule.ts",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",
     "format": "oxfmt --write .",

--- a/scripts/check-recruitingSchedule.ts
+++ b/scripts/check-recruitingSchedule.ts
@@ -29,6 +29,8 @@ const department = (id: string, name = id): RecruitingDepartmentReference => ({
   basicInformation: { name, isRecruiting: true },
 });
 
+const knownDepartmentIds = new Set(['design', 'engineering']);
+
 const schedule: RecruitingScheduleDocument = {
   _id: 'schedule-1',
   title: '2026년 1학기 리쿠르팅',
@@ -56,7 +58,15 @@ const detailFor = (
   return detail;
 };
 
-const resolved = recruitingSchedule(schedule, department('design'));
+const resolved = recruitingSchedule(
+  schedule,
+  department('design'),
+  knownDepartmentIds,
+);
+assertThrows(
+  () => recruitingSchedule(schedule, department('unknown'), knownDepartmentIds),
+  'missing or broken reference',
+);
 assert(
   resolved.formSchedule.start === null && resolved.formSchedule.end === null,
   'base schedule should preserve open-ended dates',
@@ -73,8 +83,11 @@ detailFor(validStringSchedule, 'withAssignment').formSchedule = {
   end: '2026-03-02',
 };
 assert(
-  recruitingSchedule(validStringSchedule, department('design')).formSchedule
-    .start === '2026-03-01',
+  recruitingSchedule(
+    validStringSchedule,
+    department('design'),
+    knownDepartmentIds,
+  ).formSchedule.start === '2026-03-01',
   'valid exact date strings should remain valid',
 );
 
@@ -94,7 +107,11 @@ const overrideSchedule: RecruitingScheduleDocument = {
     ],
   },
 };
-const override = recruitingSchedule(overrideSchedule, department('design'));
+const override = recruitingSchedule(
+  overrideSchedule,
+  department('design'),
+  knownDepartmentIds,
+);
 assert(
   override.formSchedule.start instanceof Date &&
     override.formSchedule.start.toISOString() === '2026-03-03T00:00:00.000Z' &&
@@ -109,7 +126,7 @@ const rejects = (
   const invalid = structuredClone(schedule);
   mutate(invalid);
   assertThrows(
-    () => recruitingSchedule(invalid, department('design')),
+    () => recruitingSchedule(invalid, department('design'), knownDepartmentIds),
     message,
   );
 };

--- a/scripts/check-recruitingSchedule.ts
+++ b/scripts/check-recruitingSchedule.ts
@@ -1,0 +1,219 @@
+import recruitingSchedule, {
+  type RecruitingDepartmentReference,
+  type RecruitingScheduleDocument,
+  validateRecruitingSchedule,
+} from '../src/utils/recruitingSchedule';
+
+const assert: (condition: unknown, message: string) => asserts condition = (
+  condition,
+  message,
+) => {
+  if (!condition) throw new Error(message);
+};
+
+const assertThrows = (run: () => unknown, expectedMessage: string) => {
+  try {
+    run();
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes(expectedMessage),
+      `expected error containing: ${expectedMessage}`,
+    );
+    return;
+  }
+  throw new Error(`expected error containing: ${expectedMessage}`);
+};
+
+const department = (id: string, name = id): RecruitingDepartmentReference => ({
+  _id: id,
+  basicInformation: { name, isRecruiting: true },
+});
+
+const schedule: RecruitingScheduleDocument = {
+  _id: 'schedule-1',
+  title: '2026년 1학기 리쿠르팅',
+  isActive: true,
+  withAssignment: {
+    departments: [department('design')],
+    formSchedule: { start: null, end: null },
+    procedure: [{ step: '서류', schedule: '03.01' }],
+    departmentOverrides: [],
+  },
+  withoutAssignment: {
+    departments: [department('engineering')],
+    formSchedule: { start: new Date('2026-03-01'), end: null },
+    procedure: [{ step: '서류', schedule: '03.02' }],
+    departmentOverrides: [],
+  },
+};
+
+const detailFor = (
+  value: RecruitingScheduleDocument,
+  detailName: 'withAssignment' | 'withoutAssignment',
+) => {
+  const detail = value[detailName];
+  assert(detail, `${detailName} detail should exist in the focused fixture`);
+  return detail;
+};
+
+const resolved = recruitingSchedule(schedule, department('design'));
+assert(
+  resolved.formSchedule.start === null && resolved.formSchedule.end === null,
+  'base schedule should preserve open-ended dates',
+);
+assert(
+  resolved.procedure[0]?.step === '서류' &&
+    resolved.procedure[0].schedule === '03.01',
+  'base procedure should resolve',
+);
+
+const validStringSchedule = structuredClone(schedule);
+detailFor(validStringSchedule, 'withAssignment').formSchedule = {
+  start: '2026-03-01',
+  end: '2026-03-02',
+};
+assert(
+  recruitingSchedule(validStringSchedule, department('design')).formSchedule
+    .start === '2026-03-01',
+  'valid exact date strings should remain valid',
+);
+
+const overrideSchedule: RecruitingScheduleDocument = {
+  ...schedule,
+  withAssignment: {
+    ...detailFor(schedule, 'withAssignment'),
+    departmentOverrides: [
+      {
+        department: department('design'),
+        formSchedule: {
+          start: new Date('2026-03-03'),
+          end: new Date('2026-03-04'),
+        },
+        procedure: [{ step: '면접', schedule: '03.05' }],
+      },
+    ],
+  },
+};
+const override = recruitingSchedule(overrideSchedule, department('design'));
+assert(
+  override.formSchedule.start instanceof Date &&
+    override.formSchedule.start.toISOString() === '2026-03-03T00:00:00.000Z' &&
+    override.procedure[0]?.step === '면접',
+  'complete override should replace base schedule and procedure',
+);
+
+const rejects = (
+  mutate: (value: RecruitingScheduleDocument) => void,
+  message: string,
+) => {
+  const invalid = structuredClone(schedule);
+  mutate(invalid);
+  assertThrows(
+    () => recruitingSchedule(invalid, department('design')),
+    message,
+  );
+};
+
+const rejectsBeforeDepartmentResolution = (
+  mutate: (value: RecruitingScheduleDocument) => void,
+  message: string,
+) => {
+  const invalid = structuredClone(schedule);
+  mutate(invalid);
+  assertThrows(
+    () =>
+      validateRecruitingSchedule(invalid, new Set(['design', 'engineering'])),
+    message,
+  );
+};
+
+rejects((value) => {
+  detailFor(value, 'withAssignment').departments = [
+    department('design'),
+    department('design'),
+  ];
+}, 'duplicate reference');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withAssignment').departmentOverrides = [
+    {
+      department: department('unknown'),
+      formSchedule: { start: null, end: null },
+      procedure: [{ step: '서류', schedule: '03.01' }],
+    },
+  ];
+}, 'missing or broken reference');
+rejects((value) => {
+  detailFor(value, 'withAssignment').departmentOverrides = [
+    {
+      department: department('engineering'),
+      formSchedule: { start: null, end: null },
+      procedure: [{ step: '서류', schedule: '03.01' }],
+    },
+  ];
+}, 'outside the detail');
+rejects((value) => {
+  detailFor(value, 'withAssignment').departmentOverrides = [
+    {
+      department: department('design'),
+      formSchedule: { start: null, end: null },
+      procedure: [{ step: '서류', schedule: '03.01' }],
+    },
+    {
+      department: department('design'),
+      formSchedule: { start: null, end: null },
+      procedure: [{ step: '서류', schedule: '03.01' }],
+    },
+  ];
+}, 'duplicate reference');
+rejects((value) => {
+  detailFor(value, 'withoutAssignment').departments = [department('design')];
+}, 'maps a department more than once');
+rejects((value) => {
+  detailFor(value, 'withAssignment').procedure = [
+    { step: '서류', schedule: null },
+  ];
+}, 'incomplete');
+rejects((value) => {
+  detailFor(value, 'withoutAssignment').formSchedule = {
+    start: new Date('2026-03-10'),
+    end: new Date('2026-03-01'),
+  };
+}, 'starts after it ends');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withAssignment').procedure = null;
+}, 'missing or empty');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withoutAssignment').formSchedule = {
+    start: new Date('2026-03-10'),
+    end: new Date('2026-03-01'),
+  };
+}, 'starts after it ends');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withAssignment').formSchedule = {
+    start: new Date('not-a-date'),
+    end: null,
+  };
+}, 'formSchedule.start is invalid');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withoutAssignment').formSchedule = {
+    start: null,
+    end: new Date('not-a-date'),
+  };
+}, 'formSchedule.end is invalid');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withAssignment').formSchedule = {
+    start: '2026-02-30',
+    end: null,
+  };
+}, 'formSchedule.start is invalid');
+rejectsBeforeDepartmentResolution((value) => {
+  detailFor(value, 'withAssignment').formSchedule = {
+    start: '0',
+    end: null,
+  };
+}, 'formSchedule.start is invalid');
+rejectsBeforeDepartmentResolution((value) => {
+  Object.assign(detailFor(value, 'withAssignment'), {
+    formSchedule: { start: 0, end: null },
+  });
+}, 'formSchedule.start is invalid');

--- a/scripts/check-recruitingSchedule.ts
+++ b/scripts/check-recruitingSchedule.ts
@@ -77,6 +77,24 @@ assert(
   'base procedure should resolve',
 );
 
+const noRecruitingSchedule: RecruitingScheduleDocument =
+  structuredClone(schedule);
+for (const detailName of ['withAssignment', 'withoutAssignment'] as const) {
+  const detail = detailFor(noRecruitingSchedule, detailName);
+  assert(detail.departments, `${detailName} departments should exist`);
+  detail.departments.forEach((value) => {
+    assert(value, `${detailName} department should exist`);
+    if (value.basicInformation) value.basicInformation.isRecruiting = false;
+  });
+}
+detailFor(noRecruitingSchedule, 'withAssignment').procedure = [
+  { step: '서류', schedule: null },
+];
+assertThrows(
+  () => validateRecruitingSchedule(noRecruitingSchedule, knownDepartmentIds),
+  'incomplete',
+);
+
 const validStringSchedule = structuredClone(schedule);
 detailFor(validStringSchedule, 'withAssignment').formSchedule = {
   start: '2026-03-01',

--- a/src/utils/recruitingSchedule.ts
+++ b/src/utils/recruitingSchedule.ts
@@ -1,57 +1,375 @@
-interface RecruitingSchedule {
-  recruitingType: {
-    individualSchedule: boolean;
-    scheduleWithAssignment: boolean;
-    scheduleWithoutAssignment: boolean;
-  };
-  scheduleWithAssignmentData: { start: Date | null; end: Date | null } | null;
-  scheduleWithoutAssignmentData: {
-    start: Date | null;
-    end: Date | null;
+export interface RecruitingScheduleRange {
+  start: Date | string | null;
+  end: Date | string | null;
+}
+
+export interface RecruitingScheduleProcedureStep {
+  step: string | null;
+  schedule: string | null;
+}
+
+export interface RecruitingDepartmentReference {
+  _id: string | null;
+  basicInformation: {
+    name: string | null;
+    isRecruiting: boolean | null;
   } | null;
-  scheduleIndividualData: { start: Date | null; end: Date | null } | null;
 }
 
-interface ScheduleResult {
-  type: 'individual' | 'withAssignment' | 'withoutAssignment' | 'none';
-  formSchedule: { start: Date | null; end: Date | null } | null;
+export interface RecruitingScheduleOverride {
+  department: RecruitingDepartmentReference | null;
+  formSchedule: RecruitingScheduleRange | null;
+  procedure: (RecruitingScheduleProcedureStep | null)[] | null;
 }
 
-export default function recruitingSchedule({
-  recruitingType,
-  scheduleWithAssignmentData,
-  scheduleWithoutAssignmentData,
-  scheduleIndividualData,
-}: RecruitingSchedule): ScheduleResult | null {
-  if (recruitingType.individualSchedule) {
-    return {
-      type: 'individual',
-      formSchedule: {
-        start: scheduleIndividualData?.start || null,
-        end: scheduleIndividualData?.end || null,
-      },
-    };
+export interface RecruitingScheduleDetail {
+  departments: (RecruitingDepartmentReference | null)[] | null;
+  formSchedule: RecruitingScheduleRange | null;
+  procedure: (RecruitingScheduleProcedureStep | null)[] | null;
+  departmentOverrides: (RecruitingScheduleOverride | null)[] | null;
+}
+
+export interface RecruitingScheduleDocument {
+  _id: string | null;
+  title: string | null;
+  isActive: boolean | null;
+  withAssignment: RecruitingScheduleDetail | null;
+  withoutAssignment: RecruitingScheduleDetail | null;
+}
+
+export interface ResolvedRecruitingSchedule {
+  formSchedule: RecruitingScheduleRange;
+  procedure: RecruitingScheduleProcedureStep[];
+}
+
+type DetailName = 'withAssignment' | 'withoutAssignment';
+
+interface ValidatedOverride {
+  department: RecruitingDepartmentReference & { _id: string };
+  formSchedule: RecruitingScheduleRange;
+  procedure: RecruitingScheduleProcedureStep[];
+}
+
+export interface ValidatedRecruitingScheduleDetail {
+  departments: (RecruitingDepartmentReference & { _id: string })[];
+  formSchedule: RecruitingScheduleRange;
+  procedure: RecruitingScheduleProcedureStep[];
+  departmentOverrides: ValidatedOverride[];
+}
+
+export interface ValidatedRecruitingSchedule {
+  withAssignment: ValidatedRecruitingScheduleDetail;
+  withoutAssignment: ValidatedRecruitingScheduleDetail;
+}
+
+const documentIdentity = (schedule: RecruitingScheduleDocument) =>
+  `${schedule.title || '<untitled>'} (${schedule._id || '<missing-id>'})`;
+
+const departmentIdentity = (
+  department: RecruitingDepartmentReference | null | undefined,
+) =>
+  `${department?.basicInformation?.name || '<unnamed>'} (${department?._id || '<missing-id>'})`;
+
+const fail = (
+  schedule: RecruitingScheduleDocument,
+  department: RecruitingDepartmentReference | null | undefined,
+  message: string,
+): never => {
+  throw new Error(
+    `[recruitingSchedule ${documentIdentity(schedule)}] department ${departmentIdentity(department)}: ${message}`,
+  );
+};
+
+const requireValue = <T>(
+  value: T | null | undefined,
+  missing: () => never,
+): T => value ?? missing();
+
+const parseScheduleDate = (value: unknown): number | null => {
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+  if (typeof value !== 'string') return null;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const [year, month, day] = match.slice(1).map(Number);
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(date.getTime()) &&
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day
+    ? date.getTime()
+    : null;
+};
+
+const requireRange = (
+  schedule: RecruitingScheduleDocument,
+  department: RecruitingDepartmentReference | null | undefined,
+  detailName: DetailName,
+  formSchedule: RecruitingScheduleRange | null,
+  source = `${detailName}.formSchedule`,
+): RecruitingScheduleRange => {
+  const requiredRange = requireValue(formSchedule, () =>
+    fail(schedule, department, `${source} is missing`),
+  );
+  const { start, end } = requiredRange;
+  const startTime = start === null ? null : parseScheduleDate(start);
+  const endTime = end === null ? null : parseScheduleDate(end);
+  if (start !== null && startTime === null) {
+    fail(schedule, department, `${source}.start is invalid`);
+  }
+  if (end !== null && endTime === null) {
+    fail(schedule, department, `${source}.end is invalid`);
+  }
+  if (startTime !== null && endTime !== null && startTime > endTime) {
+    fail(schedule, department, `${source} starts after it ends`);
+  }
+  return requiredRange;
+};
+
+const requireProcedure = (
+  schedule: RecruitingScheduleDocument,
+  department: RecruitingDepartmentReference | null | undefined,
+  detailName: DetailName,
+  procedure: (RecruitingScheduleProcedureStep | null)[] | null,
+  source: string,
+): RecruitingScheduleProcedureStep[] => {
+  const completeProcedure = requireValue(procedure, () =>
+    fail(schedule, department, `${detailName}.${source} is missing or empty`),
+  );
+  if (completeProcedure.length === 0) {
+    fail(schedule, department, `${detailName}.${source} is missing or empty`);
   }
 
-  if (recruitingType.scheduleWithAssignment) {
-    return {
-      type: 'withAssignment',
-      formSchedule: {
-        start: scheduleWithAssignmentData?.start || null,
-        end: scheduleWithAssignmentData?.end || null,
-      },
-    };
+  return completeProcedure.map((rawStep, index) => {
+    const step = requireValue(rawStep, () =>
+      fail(
+        schedule,
+        department,
+        `${detailName}.${source}[${index}] is incomplete`,
+      ),
+    );
+    const stepText = step.step;
+    const scheduleText = step.schedule;
+    if (
+      typeof stepText !== 'string' ||
+      !stepText.trim() ||
+      typeof scheduleText !== 'string' ||
+      !scheduleText.trim()
+    ) {
+      fail(
+        schedule,
+        department,
+        `${detailName}.${source}[${index}] is incomplete`,
+      );
+    }
+    return { step: stepText, schedule: scheduleText };
+  });
+};
+
+const requireDepartment = (
+  schedule: RecruitingScheduleDocument,
+  department: RecruitingDepartmentReference | null | undefined,
+  source: string,
+  knownDepartmentIds?: ReadonlySet<string>,
+): RecruitingDepartmentReference & { _id: string } => {
+  const requiredDepartment = requireValue(department, () =>
+    fail(schedule, department, `${source} has a missing or broken reference`),
+  );
+  const id = requiredDepartment._id;
+  const requiredId: string =
+    typeof id === 'string' && id
+      ? id
+      : fail(
+          schedule,
+          department,
+          `${source} has a missing or broken reference`,
+        );
+  if (knownDepartmentIds && !knownDepartmentIds.has(requiredId)) {
+    fail(schedule, department, `${source} has a missing or broken reference`);
+  }
+  return { ...requiredDepartment, _id: requiredId };
+};
+
+const validateDetail = (
+  schedule: RecruitingScheduleDocument,
+  department: RecruitingDepartmentReference | null | undefined,
+  detailName: DetailName,
+  detail: RecruitingScheduleDetail | null,
+  knownDepartmentIds?: ReadonlySet<string>,
+): ValidatedRecruitingScheduleDetail => {
+  const requiredDetail = requireValue(detail, () =>
+    fail(schedule, department, `${detailName} detail is missing`),
+  );
+  const detailDepartments = requireValue(requiredDetail.departments, () =>
+    fail(schedule, department, `${detailName}.departments is missing or empty`),
+  );
+  if (detailDepartments.length === 0) {
+    fail(schedule, department, `${detailName}.departments is missing or empty`);
   }
 
-  if (recruitingType.scheduleWithoutAssignment) {
+  const departments = detailDepartments.map((candidate, index) =>
+    requireDepartment(
+      schedule,
+      candidate,
+      `${detailName}.departments[${index}]`,
+      knownDepartmentIds,
+    ),
+  );
+  const departmentIds = new Set<string>();
+  departments.forEach((candidate) => {
+    if (departmentIds.has(candidate._id)) {
+      fail(
+        schedule,
+        department,
+        `${detailName}.departments contains duplicate reference ${candidate._id}`,
+      );
+    }
+    departmentIds.add(candidate._id);
+  });
+
+  const formSchedule = requireRange(
+    schedule,
+    department,
+    detailName,
+    requiredDetail.formSchedule,
+  );
+  const procedure = requireProcedure(
+    schedule,
+    department,
+    detailName,
+    requiredDetail.procedure,
+    'procedure',
+  );
+  const overrides = requiredDetail.departmentOverrides || [];
+  const overrideIds = new Set<string>();
+  const departmentOverrides = overrides.map((rawOverride, index) => {
+    const override = requireValue(rawOverride, () =>
+      fail(
+        schedule,
+        department,
+        `${detailName}.departmentOverrides[${index}] has a missing or broken reference`,
+      ),
+    );
+    const overrideDepartment = requireDepartment(
+      schedule,
+      override.department,
+      `${detailName}.departmentOverrides[${index}].department`,
+      knownDepartmentIds,
+    );
+    if (overrideIds.has(overrideDepartment._id)) {
+      fail(
+        schedule,
+        department,
+        `${detailName}.departmentOverrides contains duplicate reference ${overrideDepartment._id}`,
+      );
+    }
+    overrideIds.add(overrideDepartment._id);
+
+    if (!departmentIds.has(overrideDepartment._id)) {
+      fail(
+        schedule,
+        department,
+        `${detailName}.departmentOverrides[${index}] references department ${overrideDepartment._id} outside the detail`,
+      );
+    }
+
     return {
-      type: 'withoutAssignment',
-      formSchedule: {
-        start: scheduleWithoutAssignmentData?.start || null,
-        end: scheduleWithoutAssignmentData?.end || null,
-      },
+      department: overrideDepartment,
+      formSchedule: requireRange(
+        schedule,
+        department,
+        detailName,
+        override.formSchedule,
+        `${detailName}.departmentOverrides[${index}].formSchedule`,
+      ),
+      procedure: requireProcedure(
+        schedule,
+        department,
+        detailName,
+        override.procedure,
+        `departmentOverrides[${index}].procedure`,
+      ),
     };
+  });
+
+  return { departments, formSchedule, procedure, departmentOverrides };
+};
+
+export const validateRecruitingSchedule = (
+  schedule: RecruitingScheduleDocument,
+  knownDepartmentIds?: ReadonlySet<string>,
+): ValidatedRecruitingSchedule => {
+  if (!schedule._id || !schedule.title?.trim() || schedule.isActive !== true) {
+    fail(schedule, null, 'active document identity and title are required');
   }
 
-  return null;
+  const details: [DetailName, RecruitingScheduleDetail | null][] = [
+    ['withAssignment', schedule.withAssignment],
+    ['withoutAssignment', schedule.withoutAssignment],
+  ];
+  const validatedDetails = details.map(
+    ([detailName, detail]): [DetailName, ValidatedRecruitingScheduleDetail] => [
+      detailName,
+      validateDetail(schedule, null, detailName, detail, knownDepartmentIds),
+    ],
+  );
+  const mappedDepartmentIds = new Set<string>();
+  validatedDetails.forEach(([detailName, detail]) => {
+    detail.departments.forEach((department, index) => {
+      if (mappedDepartmentIds.has(department._id)) {
+        fail(
+          schedule,
+          null,
+          `${detailName}.departments[${index}] maps a department more than once`,
+        );
+      }
+      mappedDepartmentIds.add(department._id);
+    });
+  });
+
+  return {
+    withAssignment: validatedDetails[0][1],
+    withoutAssignment: validatedDetails[1][1],
+  };
+};
+
+export default function recruitingSchedule(
+  schedule: RecruitingScheduleDocument,
+  department: RecruitingDepartmentReference | null,
+): ResolvedRecruitingSchedule {
+  const validatedSchedule = validateRecruitingSchedule(schedule);
+  const targetDepartment = requireDepartment(
+    schedule,
+    department,
+    'department',
+  );
+  const validatedDetails: [DetailName, ValidatedRecruitingScheduleDetail][] = [
+    ['withAssignment', validatedSchedule.withAssignment],
+    ['withoutAssignment', validatedSchedule.withoutAssignment],
+  ];
+
+  const matches = validatedDetails.filter(([, candidate]) =>
+    candidate.departments.some((item) => item._id === targetDepartment._id),
+  );
+
+  if (matches.length !== 1) {
+    fail(
+      schedule,
+      targetDepartment,
+      `must map to exactly one recruiting detail; found ${matches.length}`,
+    );
+  }
+
+  const [, detail] = matches[0];
+  const override = detail.departmentOverrides.find(
+    (candidate) => candidate.department._id === targetDepartment._id,
+  );
+
+  return {
+    formSchedule: override?.formSchedule || detail.formSchedule,
+    procedure: override?.procedure || detail.procedure,
+  };
 }

--- a/src/utils/recruitingSchedule.ts
+++ b/src/utils/recruitingSchedule.ts
@@ -339,12 +339,17 @@ export const validateRecruitingSchedule = (
 export default function recruitingSchedule(
   schedule: RecruitingScheduleDocument,
   department: RecruitingDepartmentReference | null,
+  knownDepartmentIds: ReadonlySet<string>,
 ): ResolvedRecruitingSchedule {
-  const validatedSchedule = validateRecruitingSchedule(schedule);
+  const validatedSchedule = validateRecruitingSchedule(
+    schedule,
+    knownDepartmentIds,
+  );
   const targetDepartment = requireDepartment(
     schedule,
     department,
     'department',
+    knownDepartmentIds,
   );
   const validatedDetails: [DetailName, ValidatedRecruitingScheduleDetail][] = [
     ['withAssignment', validatedSchedule.withAssignment],

--- a/studio/migrations/rs-mig-01-backfill/check.ts
+++ b/studio/migrations/rs-mig-01-backfill/check.ts
@@ -69,6 +69,17 @@ assert(
   'individual override should be copied',
 );
 
+const omittedLegacyFlags = documents.map((document) => {
+  if (document._id !== 'x') return document;
+  const { isActive: _isActive, ...withoutActiveFlag } = document;
+  return withoutActiveFlag;
+});
+const omittedFirst = planBackfill(omittedLegacyFlags);
+assert(
+  omittedFirst.setActive && omittedFirst.setTarget,
+  'legacy O/X documents may omit isActive on the initial backfill',
+);
+
 const enriched = documents.map((document) =>
   document._id === 'o'
     ? {
@@ -111,6 +122,28 @@ expectAbort(
   invalid,
   'duplicate O/X title pair should abort',
   'expected exactly one',
+);
+const activeX = documents.map((document) =>
+  document._id === 'x' ? { ...document, isActive: true } : document,
+);
+expectAbort(
+  activeX,
+  'selected active X should abort',
+  'selected legacy X schedule',
+);
+const unknownActive = [
+  ...documents,
+  {
+    _id: 'unrelated',
+    _type: 'recruitingSchedule',
+    title: 'unrelated',
+    isActive: undefined,
+  },
+];
+expectAbort(
+  unknownActive,
+  'unrelated schedule without isActive should abort',
+  'unexpected non-inactive schedule',
 );
 
 const draftFixture = documents.map((document) =>
@@ -155,6 +188,44 @@ assert(
     !cleanupFirst.unsetLegacyRoots,
   'first cleanup should delete X and unset only allowlisted department procedures',
 );
+const partialCleanup = planCleanup(
+  enriched
+    .filter((document) => document._id !== 'x')
+    .map((document) => {
+      if (document._id !== 'with') return document;
+      const { applyProcedure: _applyProcedure, ...withoutProcedure } = document;
+      return withoutProcedure;
+    }),
+  cleanupManifest,
+);
+assert(
+  !partialCleanup.deleteLegacyX &&
+    partialCleanup.unsetApplyProcedureIds.length === 2 &&
+    partialCleanup.unsetApplyProcedureIds.includes('individual') &&
+    partialCleanup.unsetApplyProcedureIds.includes('without'),
+  'cleanup should plan only remaining department unsets after X was already deleted',
+);
+
+const rootsAlreadyRemoved = enriched
+  .filter((document) => document._id !== 'x')
+  .map((document) => {
+    if (document._id !== 'o') return document;
+    const {
+      formSchedule: _formSchedule,
+      procedure: _procedure,
+      ...withoutRoots
+    } = document;
+    return withoutRoots;
+  });
+const rootsCleanup = planCleanup(rootsAlreadyRemoved, {
+  ...cleanupManifest,
+  removeLegacyRoots: true,
+});
+assert(
+  !rootsCleanup.unsetLegacyRoots,
+  'cleanup should tolerate already-removed optional O legacy roots',
+);
+
 const cleanupRerun = planCleanup(
   enriched
     .filter((document) => document._id !== 'x')

--- a/studio/migrations/rs-mig-01-backfill/check.ts
+++ b/studio/migrations/rs-mig-01-backfill/check.ts
@@ -1,0 +1,185 @@
+import {
+  planBackfill,
+  planCleanup,
+  type CleanupManifest,
+  type RawDocument,
+} from './lib';
+
+const assert = (condition: unknown, message: string) => {
+  if (!condition) throw new Error(message);
+};
+
+const documents: RawDocument[] = [
+  {
+    _id: 'o',
+    _type: 'recruitingSchedule',
+    title: '2026년 1학기 리쿠르팅 - 과제 O',
+    formSchedule: { start: '2026-03-01', end: '2026-03-10' },
+    procedure: [{ _key: 'o-step', step: '서류', schedule: '03.01' }],
+  },
+  {
+    _id: 'x',
+    _type: 'recruitingSchedule',
+    title: '2026년 1학기 리쿠르팅 - 과제 X',
+    isActive: false,
+    formSchedule: { start: '2026-03-02', end: '2026-03-11' },
+    procedure: [{ _key: 'x-step', step: '서류', schedule: '03.02' }],
+  },
+  {
+    _id: 'with',
+    _type: 'department',
+    basicInformation: { isRecruiting: true },
+    applyProcedure: {
+      scheduleWithAssignment: true,
+      scheduleWithoutAssignment: false,
+      individualSchedule: false,
+    },
+  },
+  {
+    _id: 'individual',
+    _type: 'department',
+    basicInformation: { isRecruiting: true },
+    applyProcedure: {
+      scheduleWithAssignment: false,
+      scheduleWithoutAssignment: false,
+      individualSchedule: true,
+      formSchedule: { start: '2026-03-04', end: '2026-03-12' },
+      procedure: [{ _key: 'individual-step', step: '서류', schedule: '03.04' }],
+    },
+  },
+  {
+    _id: 'without',
+    _type: 'department',
+    basicInformation: { isRecruiting: true },
+    applyProcedure: {
+      scheduleWithAssignment: false,
+      scheduleWithoutAssignment: true,
+      individualSchedule: false,
+    },
+  },
+];
+
+const first = planBackfill(documents);
+assert(
+  first.setActive && first.setTarget,
+  'legacy fixture should require one target patch',
+);
+assert(
+  first.target.withoutAssignment.departmentOverrides.length === 1,
+  'individual override should be copied',
+);
+
+const enriched = documents.map((document) =>
+  document._id === 'o'
+    ? {
+        ...document,
+        isActive: true,
+        withAssignment: first.target.withAssignment,
+        withoutAssignment: first.target.withoutAssignment,
+      }
+    : document,
+);
+const second = planBackfill(enriched);
+assert(
+  !second.setActive && !second.setTarget,
+  'identical second run should be a no-op',
+);
+
+const expectAbort = (
+  fixture: RawDocument[],
+  message: string,
+  expectedText: string,
+  plan: (documents: RawDocument[]) => unknown = planBackfill,
+) => {
+  try {
+    plan(fixture);
+    throw new Error(message);
+  } catch (error) {
+    assert(
+      error instanceof Error && error.message.includes(expectedText),
+      `${message}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+};
+
+const invalid = documents.map((document) =>
+  document._id === 'x'
+    ? { ...document, title: '2026년 1학기 리쿠르팅 - 과제 O' }
+    : document,
+);
+expectAbort(
+  invalid,
+  'duplicate O/X title pair should abort',
+  'expected exactly one',
+);
+
+const draftFixture = documents.map((document) =>
+  document._id === 'o' ? { ...document, _id: 'drafts.o' } : document,
+);
+expectAbort(
+  draftFixture,
+  'draft recruitingSchedule should abort before selection',
+  'draft document drafts.o',
+);
+
+const collisionFixture = [
+  ...documents,
+  ...['a.b', 'a_b'].map((id) => ({
+    _id: id,
+    _type: 'department',
+    basicInformation: { isRecruiting: true },
+    applyProcedure: {
+      scheduleWithAssignment: true,
+      scheduleWithoutAssignment: false,
+      individualSchedule: false,
+    },
+  })),
+];
+expectAbort(
+  collisionFixture,
+  'normalized department IDs should not share generated _key',
+  'generated _key collision',
+);
+
+const cleanupManifest: CleanupManifest = {
+  backfillTargetFingerprint: first.backfillTargetFingerprint,
+  departmentIds: first.departmentIds,
+  legacyOId: first.legacyOId,
+  legacyXId: first.legacyXId,
+  removeLegacyRoots: false,
+};
+const cleanupFirst = planCleanup(enriched, cleanupManifest);
+assert(
+  cleanupFirst.deleteLegacyX &&
+    cleanupFirst.unsetApplyProcedureIds.length === 3 &&
+    !cleanupFirst.unsetLegacyRoots,
+  'first cleanup should delete X and unset only allowlisted department procedures',
+);
+const cleanupRerun = planCleanup(
+  enriched
+    .filter((document) => document._id !== 'x')
+    .map((document) => {
+      if (document._type !== 'department') return document;
+      const { applyProcedure: _applyProcedure, ...withoutProcedure } = document;
+      return withoutProcedure;
+    }),
+  cleanupManifest,
+);
+assert(
+  !cleanupRerun.deleteLegacyX &&
+    cleanupRerun.unsetApplyProcedureIds.length === 0 &&
+    !cleanupRerun.unsetLegacyRoots,
+  'cleanup rerun should validate the fingerprint and be a no-op',
+);
+expectAbort(
+  enriched,
+  'cleanup should reject a changed target fingerprint',
+  'target fingerprint',
+  (fixture) =>
+    planCleanup(fixture, {
+      ...cleanupManifest,
+      backfillTargetFingerprint: 'changed',
+    }),
+);
+
+process.stdout.write('RS-MIG-01 pure check passed\n');

--- a/studio/migrations/rs-mig-01-backfill/check.ts
+++ b/studio/migrations/rs-mig-01-backfill/check.ts
@@ -188,6 +188,22 @@ assert(
     !cleanupFirst.unsetLegacyRoots,
   'first cleanup should delete X and unset only allowlisted department procedures',
 );
+const xPresentPartialCleanup = planCleanup(
+  enriched.map((document) => {
+    if (document._id !== 'with') return document;
+    const { applyProcedure: _applyProcedure, ...withoutProcedure } = document;
+    return withoutProcedure;
+  }),
+  cleanupManifest,
+);
+assert(
+  xPresentPartialCleanup.deleteLegacyX &&
+    xPresentPartialCleanup.unsetApplyProcedureIds.length === 2 &&
+    xPresentPartialCleanup.unsetApplyProcedureIds.includes('individual') &&
+    xPresentPartialCleanup.unsetApplyProcedureIds.includes('without'),
+  'cleanup should plan X deletion and only remaining unsets when X remains',
+);
+
 const partialCleanup = planCleanup(
   enriched
     .filter((document) => document._id !== 'x')

--- a/studio/migrations/rs-mig-01-backfill/index.ts
+++ b/studio/migrations/rs-mig-01-backfill/index.ts
@@ -1,0 +1,26 @@
+import { at, defineMigration, patch, set } from 'sanity/migrate';
+
+import { planBackfill, type RawDocument } from './lib';
+
+export default defineMigration({
+  title: 'RS-MIG-01 backfill recruiting schedule targets',
+  documentTypes: ['recruitingSchedule', 'department'],
+  migrate: async function* (documents) {
+    const source: RawDocument[] = [];
+    for await (const document of documents())
+      source.push(document as RawDocument);
+
+    const plan = planBackfill(source);
+    if (!plan.setTarget && !plan.setActive) return;
+
+    const operations = [];
+    if (plan.setActive) operations.push(at('isActive', set(true)));
+    if (plan.setTarget) {
+      operations.push(at('withAssignment', set(plan.target.withAssignment)));
+      operations.push(
+        at('withoutAssignment', set(plan.target.withoutAssignment)),
+      );
+    }
+    yield patch(plan.targetId, operations);
+  },
+});

--- a/studio/migrations/rs-mig-01-backfill/lib.ts
+++ b/studio/migrations/rs-mig-01-backfill/lib.ts
@@ -258,11 +258,7 @@ const parseDate = (
 const targetKey = (prefix: string, id: string) =>
   `${prefix}-${id}`.replace(/[^A-Za-z0-9_-]/g, '_');
 
-const targetReference = (
-  documents: RawDocument[],
-  id: string,
-  prefix: string,
-): TargetReference => ({
+const targetReference = (id: string, prefix: string): TargetReference => ({
   _key: targetKey(prefix, id),
   _ref: id,
   _type: 'reference',
@@ -430,11 +426,8 @@ const departmentGroups = (
   };
 };
 
-const departmentReference = (
-  documents: RawDocument[],
-  department: RawDocument,
-  prefix: string,
-) => targetReference(documents, idOf(department, 'department'), prefix);
+const departmentReference = (department: RawDocument, prefix: string) =>
+  targetReference(idOf(department, 'department'), prefix);
 
 const buildDetail = (
   documents: RawDocument[],
@@ -455,7 +448,7 @@ const buildDetail = (
     if (departmentIds.has(id))
       abort(documents, `duplicate target department ID ${id}`);
     departmentIds.add(id);
-    const reference = departmentReference(documents, department, 'department');
+    const reference = departmentReference(department, 'department');
     if (referenceKeys.has(reference._key)) {
       abort(
         documents,
@@ -483,11 +476,7 @@ const buildDetail = (
     return {
       _key: key,
       _type: 'object' as const,
-      department: departmentReference(
-        documents,
-        department,
-        'override-department',
-      ),
+      department: departmentReference(department, 'override-department'),
       formSchedule: targetDate(
         documents,
         legacy.formSchedule,
@@ -512,6 +501,7 @@ const buildDetail = (
 const assertScheduleStates = (
   documents: RawDocument[],
   selectedOId: string,
+  selectedXId: string,
 ) => {
   documents
     .filter((doc) => doc._type === 'recruitingSchedule')
@@ -520,7 +510,17 @@ const assertScheduleStates = (
       if (doc.isActive !== undefined && typeof doc.isActive !== 'boolean') {
         abort(documents, `recruitingSchedule ${id} has malformed isActive`);
       }
-      if (id !== selectedOId && doc.isActive !== false) {
+      if (
+        id === selectedXId &&
+        doc.isActive !== undefined &&
+        doc.isActive !== false
+      ) {
+        abort(
+          documents,
+          `selected legacy X schedule ${id} must be inactive or omit isActive`,
+        );
+      }
+      if (id !== selectedOId && id !== selectedXId && doc.isActive !== false) {
         abort(
           documents,
           `unexpected non-inactive schedule ${id} "${titleOf(doc)}" isActive=${String(doc.isActive)}`,
@@ -566,7 +566,7 @@ export const planBackfill = (documents: RawDocument[]): BackfillPlan => {
   const { o, x } = pair(documents);
   const legacyOId = idOf(o, 'recruitingSchedule');
   const legacyXId = idOf(x, 'recruitingSchedule');
-  assertScheduleStates(documents, legacyOId);
+  assertScheduleStates(documents, legacyOId, legacyXId);
 
   const departments = collectById(documents, 'department');
   const groups = departmentGroups(documents, departments);
@@ -805,13 +805,6 @@ export const planCleanup = (
     manifest.departmentIds.forEach((id) => {
       if (!departmentIds.has(id))
         abort(documents, `cleanup department ID ${id} was not found`);
-      const department = departments.find((candidate) => candidate._id === id);
-      if (department && hasOwn(department, 'applyProcedure')) {
-        abort(
-          documents,
-          `cleanup is not a no-op: department ${id} still has applyProcedure`,
-        );
-      }
     });
   }
 
@@ -833,5 +826,3 @@ export const planCleanup = (
     unsetLegacyRoots: manifest.removeLegacyRoots && hasLegacyRoots(selectedO),
   };
 };
-
-export const targetForCheck = (plan: BackfillPlan) => plan.target;

--- a/studio/migrations/rs-mig-01-backfill/lib.ts
+++ b/studio/migrations/rs-mig-01-backfill/lib.ts
@@ -656,38 +656,72 @@ export const planBackfill = (documents: RawDocument[]): BackfillPlan => {
   };
 };
 
-const assertManifest = (
-  documents: RawDocument[],
-  plan: BackfillPlan,
-  manifest: CleanupManifest,
-) => {
-  if (
-    manifest.legacyOId !== plan.legacyOId ||
-    manifest.legacyXId !== plan.legacyXId
-  ) {
-    abort(
-      documents,
-      `cleanup manifest schedule IDs do not match validated pair: O=${manifest.legacyOId}, X=${manifest.legacyXId}`,
-    );
-  }
-  if (manifest.backfillTargetFingerprint !== plan.backfillTargetFingerprint) {
-    abort(
-      documents,
-      `cleanup manifest target fingerprint does not match validated O target: expected ${plan.backfillTargetFingerprint}, received ${manifest.backfillTargetFingerprint}`,
-    );
-  }
-  const expected = [...plan.departmentIds].sort();
-  const actual = [...manifest.departmentIds].sort();
-  if (!sameValue(actual, expected)) {
-    abort(
-      documents,
-      `cleanup manifest department allowlist does not exactly match backfill IDs: expected ${expected.join(', ') || '<none>'}, received ${actual.join(', ') || '<none>'}`,
-    );
-  }
-};
-
 const hasLegacyRoots = (schedule: RawDocument) =>
   hasOwn(schedule, 'formSchedule') || hasOwn(schedule, 'procedure');
+
+const targetDepartmentIds = (
+  documents: RawDocument[],
+  schedule: RawDocument,
+): string[] => {
+  const ids = new Set<string>();
+  for (const detailName of ['withAssignment', 'withoutAssignment'] as const) {
+    const detail = schedule[detailName];
+    const detailRecord: RawDocument = isRecord(detail)
+      ? detail
+      : abort(
+          documents,
+          `selected O schedule ${idOf(schedule, 'recruitingSchedule')} has malformed ${detailName} target departments`,
+        );
+    const references: unknown[] = Array.isArray(detailRecord.departments)
+      ? detailRecord.departments
+      : abort(
+          documents,
+          `selected O schedule ${idOf(schedule, 'recruitingSchedule')} has malformed ${detailName} target departments`,
+        );
+    for (const [index, reference] of references.entries()) {
+      const referenceId =
+        isRecord(reference) &&
+        typeof reference._ref === 'string' &&
+        reference._ref.trim()
+          ? reference._ref
+          : abort(
+              documents,
+              `selected O schedule ${idOf(schedule, 'recruitingSchedule')} has malformed ${detailName}.departments[${index}] target reference`,
+            );
+      if (ids.has(referenceId)) {
+        abort(
+          documents,
+          `selected O schedule ${idOf(schedule, 'recruitingSchedule')} maps department ${referenceId} more than once`,
+        );
+      }
+      ids.add(referenceId);
+    }
+  }
+  return [...ids].sort();
+};
+
+const assertCleanupDepartmentAllowlist = (
+  documents: RawDocument[],
+  departments: RawDocument[],
+  o: RawDocument,
+  manifest: CleanupManifest,
+) => {
+  const targetIds = targetDepartmentIds(documents, o);
+  const manifestIds = [...manifest.departmentIds].sort();
+  if (!sameValue(manifestIds, targetIds)) {
+    abort(
+      documents,
+      `cleanup manifest department allowlist does not exactly match O target IDs: expected ${targetIds.join(', ') || '<none>'}, received ${manifestIds.join(', ') || '<none>'}`,
+    );
+  }
+  const departmentIds = new Set(
+    departments.map((department) => idOf(department, 'department')),
+  );
+  manifest.departmentIds.forEach((id) => {
+    if (!departmentIds.has(id))
+      abort(documents, `cleanup department ID ${id} was not found`);
+  });
+};
 
 const assertAlreadyBackfilledO = (documents: RawDocument[], o: RawDocument) => {
   const id = idOf(o, 'recruitingSchedule');
@@ -763,14 +797,36 @@ export const planCleanup = (
 
   const xStillExists = Boolean(x);
   if (xStillExists) {
-    const plan = planBackfill(documents);
-    assertManifest(documents, plan, manifest);
-    if (plan.targetId !== manifest.legacyOId) {
+    const paired = pair(documents);
+    const selectedX = paired.x;
+    const selectedOId = idOf(paired.o, 'recruitingSchedule');
+    const selectedXId = idOf(selectedX, 'recruitingSchedule');
+    if (
+      selectedOId !== manifest.legacyOId ||
+      selectedXId !== manifest.legacyXId
+    ) {
       abort(
         documents,
-        `cleanup target O ID ${manifest.legacyOId} is not the validated target`,
+        `cleanup manifest schedule IDs do not match validated pair: O=${manifest.legacyOId}, X=${manifest.legacyXId}`,
       );
     }
+    assertScheduleStates(documents, selectedOId, selectedXId);
+    assertAlreadyBackfilledO(documents, paired.o);
+    if (
+      targetFingerprintOfDocument(documents, paired.o) !==
+      manifest.backfillTargetFingerprint
+    ) {
+      abort(
+        documents,
+        `cleanup manifest target fingerprint does not match O document ${manifest.legacyOId}`,
+      );
+    }
+    assertCleanupDepartmentAllowlist(
+      documents,
+      departments,
+      paired.o,
+      manifest,
+    );
   } else {
     const otherLegacyX = schedules.filter(
       (schedule) => titleParts(schedule.title)?.mode === 'X',
@@ -799,13 +855,12 @@ export const planCleanup = (
       );
     }
     assertPostBackfillScheduleStates(documents, manifest.legacyOId);
-    const departmentIds = new Set(
-      departments.map((department) => idOf(department, 'department')),
+    assertCleanupDepartmentAllowlist(
+      documents,
+      departments,
+      selectedO,
+      manifest,
     );
-    manifest.departmentIds.forEach((id) => {
-      if (!departmentIds.has(id))
-        abort(documents, `cleanup department ID ${id} was not found`);
-    });
   }
 
   const unsetApplyProcedureIds = departments

--- a/studio/migrations/rs-mig-01-backfill/lib.ts
+++ b/studio/migrations/rs-mig-01-backfill/lib.ts
@@ -1,0 +1,837 @@
+export type RawDocument = {
+  _id?: unknown;
+  _type?: unknown;
+  [key: string]: unknown;
+};
+
+type LegacyMode = 'withAssignment' | 'withoutAssignment' | 'individual';
+type TargetDetail = {
+  _type: 'recruitingScheduleContent';
+  departments: TargetReference[];
+  formSchedule: TargetDateContent;
+  procedure: TargetProcedureStep[];
+  departmentOverrides: TargetDepartmentOverride[];
+};
+
+type TargetReference = {
+  _key: string;
+  _ref: string;
+  _type: 'reference';
+};
+type TargetDateContent = {
+  _type: 'dateContent';
+  end: string | null;
+  start: string | null;
+};
+type TargetProcedureStep = {
+  _key: string;
+  _type: 'applyStepContent';
+  schedule: string;
+  step: string;
+};
+type TargetDepartmentOverride = {
+  _key: string;
+  _type: 'object';
+  department: TargetReference;
+  formSchedule: TargetDateContent;
+  procedure: TargetProcedureStep[];
+};
+
+export type BackfillPlan = {
+  backfillTargetFingerprint: string;
+  departmentIds: string[];
+  legacyOId: string;
+  legacyXId: string;
+  target: {
+    withAssignment: TargetDetail;
+    withoutAssignment: TargetDetail;
+  };
+  targetId: string;
+  setTarget: boolean;
+  setActive: boolean;
+};
+
+export type CleanupManifest = {
+  backfillTargetFingerprint: string;
+  departmentIds: string[];
+  legacyOId: string;
+  legacyXId: string;
+  removeLegacyRoots: boolean;
+};
+
+export type CleanupPlan = {
+  deleteLegacyX: boolean;
+  legacyOId: string;
+  legacyXId: string;
+  unsetApplyProcedureIds: string[];
+  unsetLegacyRoots: boolean;
+};
+
+const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
+
+const isRecord = (value: unknown): value is RawDocument =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const idOf = (doc: RawDocument, context: string): string => {
+  if (typeof doc._id !== 'string' || !doc._id.trim()) {
+    const title = typeof doc.title === 'string' ? ` title="${doc.title}"` : '';
+    const departmentName =
+      isRecord(doc.basicInformation) &&
+      typeof doc.basicInformation.name === 'string'
+        ? ` name="${doc.basicInformation.name}"`
+        : '';
+    throw new Error(
+      `${context} has a missing document ID;${title}${departmentName}`,
+    );
+  }
+  return doc._id;
+};
+
+const displayId = (doc: RawDocument) =>
+  typeof doc._id === 'string' && doc._id.trim() ? doc._id : '<missing-id>';
+
+const titleOf = (doc: RawDocument) =>
+  typeof doc.title === 'string' && doc.title.trim()
+    ? doc.title
+    : '<missing-title>';
+
+const nameOf = (doc: RawDocument) => {
+  const basicInformation = isRecord(doc.basicInformation)
+    ? doc.basicInformation
+    : null;
+  return typeof basicInformation?.name === 'string' &&
+    basicInformation.name.trim()
+    ? basicInformation.name
+    : '<unnamed>';
+};
+
+const inventory = (documents: RawDocument[]) => {
+  const schedules = documents.filter(
+    (doc) => doc._type === 'recruitingSchedule',
+  );
+  const departments = documents.filter((doc) => doc._type === 'department');
+  const scheduleReport = schedules.length
+    ? schedules
+        .map(
+          (doc) =>
+            `${displayId(doc)} "${titleOf(doc)}" isActive=${String(doc.isActive)}`,
+        )
+        .join(', ')
+    : '<none>';
+  const departmentReport = departments.length
+    ? departments.map((doc) => `${displayId(doc)} "${nameOf(doc)}"`).join(', ')
+    : '<none>';
+  return `Relevant recruitingSchedule IDs/titles: ${scheduleReport}\nRelevant department IDs/names: ${departmentReport}`;
+};
+
+const abort = (documents: RawDocument[], message: string): never => {
+  throw new Error(
+    `RS-MIG-01 preflight aborted: ${message}\n${inventory(documents)}`,
+  );
+};
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+};
+
+const sameValue = (left: unknown, right: unknown) =>
+  stableStringify(left) === stableStringify(right);
+
+const targetFingerprint = (
+  id: string,
+  title: string,
+  target: {
+    withAssignment: TargetDetail;
+    withoutAssignment: TargetDetail;
+  },
+) =>
+  stableStringify({
+    _id: id,
+    title,
+    withAssignment: target.withAssignment,
+    withoutAssignment: target.withoutAssignment,
+  });
+
+const targetFingerprintOfDocument = (
+  documents: RawDocument[],
+  schedule: RawDocument,
+) => {
+  const id = idOf(schedule, 'recruitingSchedule');
+  if (typeof schedule.title !== 'string' || !schedule.title.trim()) {
+    abort(documents, `recruitingSchedule ${id} is missing a title`);
+  }
+  if (
+    !isRecord(schedule.withAssignment) ||
+    !isRecord(schedule.withoutAssignment)
+  ) {
+    abort(
+      documents,
+      `recruitingSchedule ${id} is missing a complete target payload`,
+    );
+  }
+  return targetFingerprint(id, schedule.title as string, {
+    withAssignment: schedule.withAssignment as TargetDetail,
+    withoutAssignment: schedule.withoutAssignment as TargetDetail,
+  });
+};
+
+const assertNoDraftDocuments = (documents: RawDocument[]) => {
+  const draft = documents.find(
+    (document) =>
+      (document._type === 'recruitingSchedule' ||
+        document._type === 'department') &&
+      typeof document._id === 'string' &&
+      document._id.startsWith('drafts.'),
+  );
+  if (draft) {
+    abort(
+      documents,
+      `draft document ${draft._id as string} is present; published documents only are required`,
+    );
+  }
+};
+
+const titleParts = (
+  title: unknown,
+): { mode: 'O' | 'X'; prefix: string } | null => {
+  if (typeof title !== 'string') return null;
+  const match = /^(.*?)\s*-\s*과제 ([OX])$/.exec(title.trim());
+  if (!match || !match[1].trim()) return null;
+  return { mode: match[2] as 'O' | 'X', prefix: match[1].trim() };
+};
+
+const collectById = (
+  documents: RawDocument[],
+  type: 'department' | 'recruitingSchedule',
+): RawDocument[] => {
+  const matching = documents.filter((doc) => doc._type === type);
+  const ids = new Set<string>();
+  matching.forEach((doc) => {
+    const id = idOf(doc, type);
+    if (ids.has(id)) abort(documents, `duplicate ${type} ID ${id}`);
+    ids.add(id);
+  });
+  return matching;
+};
+
+const assertBoolean = (
+  documents: RawDocument[],
+  value: unknown,
+  path: string,
+): boolean => {
+  if (typeof value !== 'boolean') abort(documents, `${path} must be boolean`);
+  return value as boolean;
+};
+
+const parseDate = (
+  documents: RawDocument[],
+  value: unknown,
+  path: string,
+): string | null => {
+  if (value === null) return null;
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    abort(documents, `${path} is malformed; expected YYYY-MM-DD or null`);
+  }
+  const dateValue = value as string;
+  const [year, month, day] = dateValue.split('-').map(Number);
+  const date = new Date(`${dateValue}T00:00:00.000Z`);
+  if (
+    !Number.isFinite(date.getTime()) ||
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
+  ) {
+    abort(documents, `${path} is malformed; expected a real calendar date`);
+  }
+  return dateValue;
+};
+
+const targetKey = (prefix: string, id: string) =>
+  `${prefix}-${id}`.replace(/[^A-Za-z0-9_-]/g, '_');
+
+const targetReference = (
+  documents: RawDocument[],
+  id: string,
+  prefix: string,
+): TargetReference => ({
+  _key: targetKey(prefix, id),
+  _ref: id,
+  _type: 'reference',
+});
+
+const targetDate = (
+  documents: RawDocument[],
+  value: unknown,
+  path: string,
+): TargetDateContent => {
+  if (!isRecord(value)) abort(documents, `${path} is missing or malformed`);
+  const dateValue = value as RawDocument;
+  return {
+    _type: 'dateContent',
+    end: parseDate(documents, dateValue.end, `${path}.end`),
+    start: parseDate(documents, dateValue.start, `${path}.start`),
+  };
+};
+
+const targetProcedure = (
+  documents: RawDocument[],
+  value: unknown,
+  path: string,
+): TargetProcedureStep[] => {
+  if (!Array.isArray(value) || value.length === 0) {
+    abort(documents, `${path} is missing or empty`);
+  }
+  const candidates = value as unknown[];
+  const keys = new Set<string>();
+  return candidates.map((candidate, index) => {
+    if (!isRecord(candidate))
+      abort(documents, `${path}[${index}] is incomplete`);
+    const stepValue = candidate as RawDocument;
+    if (
+      typeof stepValue.step !== 'string' ||
+      !stepValue.step.trim() ||
+      typeof stepValue.schedule !== 'string' ||
+      !stepValue.schedule.trim()
+    ) {
+      abort(documents, `${path}[${index}] is incomplete`);
+    }
+    const key =
+      typeof stepValue._key === 'string' && stepValue._key.trim()
+        ? stepValue._key
+        : targetKey(`procedure-${index}`, path);
+    if (keys.has(key))
+      abort(documents, `${path} contains duplicate _key ${key}`);
+    keys.add(key);
+    return {
+      _key: key,
+      _type: 'applyStepContent',
+      schedule: stepValue.schedule as string,
+      step: stepValue.step as string,
+    };
+  });
+};
+
+const completeLegacySchedule = (
+  documents: RawDocument[],
+  schedule: RawDocument,
+  label: string,
+) => {
+  const id = idOf(schedule, 'recruitingSchedule');
+  return {
+    formSchedule: targetDate(
+      documents,
+      schedule.formSchedule,
+      `${label} ${id}.formSchedule`,
+    ),
+    procedure: targetProcedure(
+      documents,
+      schedule.procedure,
+      `${label} ${id}.procedure`,
+    ),
+  };
+};
+
+const legacyMode = (
+  documents: RawDocument[],
+  department: RawDocument,
+): LegacyMode | null => {
+  const id = idOf(department, 'department');
+  const recruiting = isRecord(department.basicInformation)
+    ? department.basicInformation.isRecruiting
+    : undefined;
+  if (typeof recruiting !== 'boolean') {
+    abort(
+      documents,
+      `department ${id} is missing basicInformation.isRecruiting`,
+    );
+  }
+
+  const applyProcedure = department.applyProcedure;
+  if (applyProcedure === undefined || applyProcedure === null) {
+    if (recruiting)
+      abort(documents, `recruiting department ${id} is missing applyProcedure`);
+    return null;
+  }
+  if (!isRecord(applyProcedure)) {
+    abort(documents, `department ${id}.applyProcedure is malformed`);
+  }
+  const legacy = applyProcedure as RawDocument;
+
+  const flags = {
+    individual: assertBoolean(
+      documents,
+      legacy.individualSchedule,
+      `department ${id}.applyProcedure.individualSchedule`,
+    ),
+    withAssignment: assertBoolean(
+      documents,
+      legacy.scheduleWithAssignment,
+      `department ${id}.applyProcedure.scheduleWithAssignment`,
+    ),
+    withoutAssignment: assertBoolean(
+      documents,
+      legacy.scheduleWithoutAssignment,
+      `department ${id}.applyProcedure.scheduleWithoutAssignment`,
+    ),
+  };
+  const enabled = Object.entries(flags)
+    .filter(([, value]) => value)
+    .map(([key]) => key as LegacyMode);
+  if (!recruiting) {
+    if (enabled.length > 0) {
+      abort(
+        documents,
+        `non-recruiting department ${id} has a legacy recruiting mode`,
+      );
+    }
+    return null;
+  }
+  if (enabled.length !== 1) {
+    abort(
+      documents,
+      `recruiting department ${id} must have exactly one legacy mode; found ${enabled.join(', ') || 'none'}`,
+    );
+  }
+  return enabled[0];
+};
+
+const departmentGroups = (
+  documents: RawDocument[],
+  departments: RawDocument[],
+) => {
+  const withAssignment: RawDocument[] = [];
+  const withoutAssignment: RawDocument[] = [];
+  const individual: RawDocument[] = [];
+  departments.forEach((department) => {
+    const mode = legacyMode(documents, department);
+    if (mode === 'withAssignment') withAssignment.push(department);
+    if (mode === 'withoutAssignment') withoutAssignment.push(department);
+    if (mode === 'individual') individual.push(department);
+  });
+  return {
+    individual: individual.sort((left, right) =>
+      idOf(left, 'department').localeCompare(idOf(right, 'department')),
+    ),
+    withAssignment: withAssignment.sort((left, right) =>
+      idOf(left, 'department').localeCompare(idOf(right, 'department')),
+    ),
+    withoutAssignment: withoutAssignment.sort((left, right) =>
+      idOf(left, 'department').localeCompare(idOf(right, 'department')),
+    ),
+  };
+};
+
+const departmentReference = (
+  documents: RawDocument[],
+  department: RawDocument,
+  prefix: string,
+) => targetReference(documents, idOf(department, 'department'), prefix);
+
+const buildDetail = (
+  documents: RawDocument[],
+  source: { formSchedule: TargetDateContent; procedure: TargetProcedureStep[] },
+  departments: RawDocument[],
+  overrides: RawDocument[],
+): TargetDetail => {
+  if (departments.length === 0) {
+    abort(
+      documents,
+      'target detail must contain at least one recruiting department',
+    );
+  }
+  const departmentIds = new Set<string>();
+  const referenceKeys = new Set<string>();
+  const refs = departments.map((department) => {
+    const id = idOf(department, 'department');
+    if (departmentIds.has(id))
+      abort(documents, `duplicate target department ID ${id}`);
+    departmentIds.add(id);
+    const reference = departmentReference(documents, department, 'department');
+    if (referenceKeys.has(reference._key)) {
+      abort(
+        documents,
+        `generated _key collision for department IDs in target detail: ${id}`,
+      );
+    }
+    referenceKeys.add(reference._key);
+    return reference;
+  });
+  const overrideKeys = new Set<string>();
+  const departmentOverrides = overrides.map((department) => {
+    const id = idOf(department, 'department');
+    const key = targetKey('override', id);
+    if (overrideKeys.has(key))
+      abort(documents, `duplicate department override key ${key}`);
+    overrideKeys.add(key);
+    const applyProcedure = department.applyProcedure;
+    if (!isRecord(applyProcedure)) {
+      abort(
+        documents,
+        `department ${id}.applyProcedure is missing for individual schedule`,
+      );
+    }
+    const legacy = applyProcedure as RawDocument;
+    return {
+      _key: key,
+      _type: 'object' as const,
+      department: departmentReference(
+        documents,
+        department,
+        'override-department',
+      ),
+      formSchedule: targetDate(
+        documents,
+        legacy.formSchedule,
+        `department ${id}.applyProcedure.formSchedule`,
+      ),
+      procedure: targetProcedure(
+        documents,
+        legacy.procedure,
+        `department ${id}.applyProcedure.procedure`,
+      ),
+    };
+  });
+  return {
+    _type: 'recruitingScheduleContent',
+    departments: refs,
+    departmentOverrides,
+    formSchedule: source.formSchedule,
+    procedure: source.procedure,
+  };
+};
+
+const assertScheduleStates = (
+  documents: RawDocument[],
+  selectedOId: string,
+) => {
+  documents
+    .filter((doc) => doc._type === 'recruitingSchedule')
+    .forEach((doc) => {
+      const id = idOf(doc, 'recruitingSchedule');
+      if (doc.isActive !== undefined && typeof doc.isActive !== 'boolean') {
+        abort(documents, `recruitingSchedule ${id} has malformed isActive`);
+      }
+      if (id !== selectedOId && doc.isActive !== false) {
+        abort(
+          documents,
+          `unexpected non-inactive schedule ${id} "${titleOf(doc)}" isActive=${String(doc.isActive)}`,
+        );
+      }
+      if (
+        id !== selectedOId &&
+        (hasOwn(doc, 'withAssignment') || hasOwn(doc, 'withoutAssignment'))
+      ) {
+        abort(
+          documents,
+          `unexpected target fields on schedule ${id} "${titleOf(doc)}"`,
+        );
+      }
+    });
+};
+
+const pair = (documents: RawDocument[]) => {
+  const schedules = collectById(documents, 'recruitingSchedule');
+  const candidates = schedules.flatMap((schedule) => {
+    const parts = titleParts(schedule.title);
+    return parts ? [{ schedule, parts }] : [];
+  });
+  const oCandidates = candidates.filter(({ parts }) => parts.mode === 'O');
+  const xCandidates = candidates.filter(({ parts }) => parts.mode === 'X');
+  if (oCandidates.length !== 1 || xCandidates.length !== 1) {
+    abort(
+      documents,
+      `expected exactly one legacy title ending "과제 O" and one ending "과제 X"; found O=${oCandidates.length}, X=${xCandidates.length}`,
+    );
+  }
+  if (oCandidates[0].parts.prefix !== xCandidates[0].parts.prefix) {
+    abort(
+      documents,
+      `legacy title pair has different cycle prefixes: "${titleOf(oCandidates[0].schedule)}" and "${titleOf(xCandidates[0].schedule)}"`,
+    );
+  }
+  return { o: oCandidates[0].schedule, x: xCandidates[0].schedule };
+};
+
+export const planBackfill = (documents: RawDocument[]): BackfillPlan => {
+  assertNoDraftDocuments(documents);
+  const { o, x } = pair(documents);
+  const legacyOId = idOf(o, 'recruitingSchedule');
+  const legacyXId = idOf(x, 'recruitingSchedule');
+  assertScheduleStates(documents, legacyOId);
+
+  const departments = collectById(documents, 'department');
+  const groups = departmentGroups(documents, departments);
+  const withSchedule = completeLegacySchedule(
+    documents,
+    o,
+    'legacy O schedule',
+  );
+  const withoutSchedule = completeLegacySchedule(
+    documents,
+    x,
+    'legacy X schedule',
+  );
+  const withoutAssignmentDepartments = [
+    ...groups.withoutAssignment,
+    ...groups.individual,
+  ].sort((left, right) =>
+    idOf(left, 'department').localeCompare(idOf(right, 'department')),
+  );
+  const target = {
+    withAssignment: buildDetail(
+      documents,
+      withSchedule,
+      groups.withAssignment,
+      [],
+    ),
+    withoutAssignment: buildDetail(
+      documents,
+      withoutSchedule,
+      withoutAssignmentDepartments,
+      groups.individual,
+    ),
+  };
+  const departmentIds = [
+    ...groups.withAssignment,
+    ...groups.withoutAssignment,
+    ...groups.individual,
+  ]
+    .map((department) => idOf(department, 'department'))
+    .sort();
+
+  const hasWith = hasOwn(o, 'withAssignment');
+  const hasWithout = hasOwn(o, 'withoutAssignment');
+  if (hasWith !== hasWithout) {
+    abort(
+      documents,
+      `selected O schedule ${legacyOId} has only one new target field`,
+    );
+  }
+  const hasTarget = hasWith && hasWithout;
+  if (hasTarget && o.isActive !== true) {
+    abort(
+      documents,
+      `selected O schedule ${legacyOId} has target fields but is not active`,
+    );
+  }
+  if (
+    hasTarget &&
+    (!sameValue(o.withAssignment, target.withAssignment) ||
+      !sameValue(o.withoutAssignment, target.withoutAssignment))
+  ) {
+    abort(
+      documents,
+      `selected O schedule ${legacyOId} has a non-identical existing target payload`,
+    );
+  }
+  if (o.isActive === true && !hasTarget) {
+    abort(
+      documents,
+      `selected O schedule ${legacyOId} is active but lacks both target payloads`,
+    );
+  }
+
+  return {
+    backfillTargetFingerprint: targetFingerprint(
+      legacyOId,
+      o.title as string,
+      target,
+    ),
+    departmentIds,
+    legacyOId,
+    legacyXId,
+    setActive: o.isActive !== true,
+    setTarget: !hasTarget,
+    target,
+    targetId: legacyOId,
+  };
+};
+
+const assertManifest = (
+  documents: RawDocument[],
+  plan: BackfillPlan,
+  manifest: CleanupManifest,
+) => {
+  if (
+    manifest.legacyOId !== plan.legacyOId ||
+    manifest.legacyXId !== plan.legacyXId
+  ) {
+    abort(
+      documents,
+      `cleanup manifest schedule IDs do not match validated pair: O=${manifest.legacyOId}, X=${manifest.legacyXId}`,
+    );
+  }
+  if (manifest.backfillTargetFingerprint !== plan.backfillTargetFingerprint) {
+    abort(
+      documents,
+      `cleanup manifest target fingerprint does not match validated O target: expected ${plan.backfillTargetFingerprint}, received ${manifest.backfillTargetFingerprint}`,
+    );
+  }
+  const expected = [...plan.departmentIds].sort();
+  const actual = [...manifest.departmentIds].sort();
+  if (!sameValue(actual, expected)) {
+    abort(
+      documents,
+      `cleanup manifest department allowlist does not exactly match backfill IDs: expected ${expected.join(', ') || '<none>'}, received ${actual.join(', ') || '<none>'}`,
+    );
+  }
+};
+
+const hasLegacyRoots = (schedule: RawDocument) =>
+  hasOwn(schedule, 'formSchedule') || hasOwn(schedule, 'procedure');
+
+const assertAlreadyBackfilledO = (documents: RawDocument[], o: RawDocument) => {
+  const id = idOf(o, 'recruitingSchedule');
+  if (
+    o.isActive !== true ||
+    !hasOwn(o, 'withAssignment') ||
+    !hasOwn(o, 'withoutAssignment')
+  ) {
+    abort(
+      documents,
+      `selected O schedule ${id} is not an active enriched target`,
+    );
+  }
+  if (!isRecord(o.withAssignment) || !isRecord(o.withoutAssignment)) {
+    abort(documents, `selected O schedule ${id} has malformed target fields`);
+  }
+};
+
+const assertPostBackfillScheduleStates = (
+  documents: RawDocument[],
+  selectedOId: string,
+) => {
+  documents
+    .filter((doc) => doc._type === 'recruitingSchedule')
+    .forEach((doc) => {
+      const id = idOf(doc, 'recruitingSchedule');
+      if (id !== selectedOId && doc.isActive !== false) {
+        abort(
+          documents,
+          `unexpected non-inactive schedule ${id} "${titleOf(doc)}" isActive=${String(doc.isActive)}`,
+        );
+      }
+      if (
+        id !== selectedOId &&
+        (hasOwn(doc, 'withAssignment') || hasOwn(doc, 'withoutAssignment'))
+      ) {
+        abort(
+          documents,
+          `unexpected target fields on schedule ${id} "${titleOf(doc)}"`,
+        );
+      }
+    });
+};
+
+export const planCleanup = (
+  documents: RawDocument[],
+  manifest: CleanupManifest,
+): CleanupPlan => {
+  assertNoDraftDocuments(documents);
+  if (
+    typeof manifest.backfillTargetFingerprint !== 'string' ||
+    !manifest.backfillTargetFingerprint ||
+    typeof manifest.legacyOId !== 'string' ||
+    typeof manifest.legacyXId !== 'string' ||
+    !Array.isArray(manifest.departmentIds) ||
+    manifest.departmentIds.length === 0 ||
+    manifest.departmentIds.some((id) => typeof id !== 'string' || !id) ||
+    new Set(manifest.departmentIds).size !== manifest.departmentIds.length ||
+    typeof manifest.removeLegacyRoots !== 'boolean'
+  ) {
+    abort(
+      documents,
+      'cleanup requires non-empty, unique exact O ID, X ID, and department allowlist',
+    );
+  }
+
+  const schedules = collectById(documents, 'recruitingSchedule');
+  const departments = collectById(documents, 'department');
+  const o = schedules.find((schedule) => schedule._id === manifest.legacyOId);
+  const x = schedules.find((schedule) => schedule._id === manifest.legacyXId);
+  if (!o) abort(documents, `cleanup O ID ${manifest.legacyOId} was not found`);
+  const selectedO = o as RawDocument;
+
+  const xStillExists = Boolean(x);
+  if (xStillExists) {
+    const plan = planBackfill(documents);
+    assertManifest(documents, plan, manifest);
+    if (plan.targetId !== manifest.legacyOId) {
+      abort(
+        documents,
+        `cleanup target O ID ${manifest.legacyOId} is not the validated target`,
+      );
+    }
+  } else {
+    const otherLegacyX = schedules.filter(
+      (schedule) => titleParts(schedule.title)?.mode === 'X',
+    );
+    if (otherLegacyX.length > 0) {
+      abort(
+        documents,
+        'validated legacy X ID is absent but another legacy X schedule exists',
+      );
+    }
+    assertAlreadyBackfilledO(documents, selectedO);
+    if (
+      targetFingerprintOfDocument(documents, selectedO) !==
+      manifest.backfillTargetFingerprint
+    ) {
+      abort(
+        documents,
+        `cleanup manifest target fingerprint does not match O document ${manifest.legacyOId}`,
+      );
+    }
+    const selectedTitle = titleParts(selectedO.title);
+    if (!selectedTitle || selectedTitle.mode !== 'O') {
+      abort(
+        documents,
+        `cleanup O document ${manifest.legacyOId} does not retain a legacy O title`,
+      );
+    }
+    assertPostBackfillScheduleStates(documents, manifest.legacyOId);
+    const departmentIds = new Set(
+      departments.map((department) => idOf(department, 'department')),
+    );
+    manifest.departmentIds.forEach((id) => {
+      if (!departmentIds.has(id))
+        abort(documents, `cleanup department ID ${id} was not found`);
+      const department = departments.find((candidate) => candidate._id === id);
+      if (department && hasOwn(department, 'applyProcedure')) {
+        abort(
+          documents,
+          `cleanup is not a no-op: department ${id} still has applyProcedure`,
+        );
+      }
+    });
+  }
+
+  const unsetApplyProcedureIds = departments
+    .filter(
+      (department) =>
+        typeof department._id === 'string' &&
+        manifest.departmentIds.includes(department._id) &&
+        hasOwn(department, 'applyProcedure'),
+    )
+    .map((department) => department._id as string)
+    .sort();
+
+  return {
+    deleteLegacyX: xStillExists,
+    legacyOId: manifest.legacyOId,
+    legacyXId: manifest.legacyXId,
+    unsetApplyProcedureIds,
+    unsetLegacyRoots: manifest.removeLegacyRoots && hasLegacyRoots(selectedO),
+  };
+};
+
+export const targetForCheck = (plan: BackfillPlan) => plan.target;

--- a/studio/migrations/rs-mig-01-cleanup/index.ts
+++ b/studio/migrations/rs-mig-01-cleanup/index.ts
@@ -1,0 +1,47 @@
+import { at, defineMigration, del, patch, unset } from 'sanity/migrate';
+
+import {
+  planCleanup,
+  type CleanupManifest,
+  type RawDocument,
+} from '../rs-mig-01-backfill/lib';
+
+const manifest: CleanupManifest = {
+  // Fill these values from the successful backfill report. Do not broaden the list.
+  // Keep this operator-local and uncommitted: it binds cleanup to one enriched O payload.
+  backfillTargetFingerprint: '',
+  departmentIds: [],
+  legacyOId: '',
+  legacyXId: '',
+  removeLegacyRoots: false,
+};
+
+export default defineMigration({
+  title: 'RS-MIG-01 cleanup validated legacy schedule data',
+  documentTypes: ['recruitingSchedule', 'department'],
+  migrate: async function* (documents) {
+    const source: RawDocument[] = [];
+    for await (const document of documents())
+      source.push(document as RawDocument);
+
+    const plan = planCleanup(source, manifest);
+    if (
+      !plan.deleteLegacyX &&
+      plan.unsetApplyProcedureIds.length === 0 &&
+      !plan.unsetLegacyRoots
+    ) {
+      return;
+    }
+
+    if (plan.deleteLegacyX) yield del(plan.legacyXId);
+    for (const departmentId of plan.unsetApplyProcedureIds) {
+      yield patch(departmentId, at('applyProcedure', unset()));
+    }
+    if (plan.unsetLegacyRoots) {
+      yield patch(plan.legacyOId, [
+        at('formSchedule', unset()),
+        at('procedure', unset()),
+      ]);
+    }
+  },
+});

--- a/studio/schemas/Documents/department.ts
+++ b/studio/schemas/Documents/department.ts
@@ -8,13 +8,6 @@ export default defineType({
   icon,
   fields: [
     defineField({
-      name: 'applyProcedure',
-      title: '지원 절차',
-      description:
-        '리쿠르팅을 진행하지 않는 경우, 모든 항목을 비활성화해주세요.',
-      type: 'recruitingScheduleContent',
-    }),
-    defineField({
       title: '부서 기본 정보',
       name: 'basicInformation',
       type: 'informationContent',

--- a/studio/schemas/Documents/recruitingSchedule.ts
+++ b/studio/schemas/Documents/recruitingSchedule.ts
@@ -10,26 +10,40 @@ export default defineType({
     defineField({
       title: '제목',
       name: 'title',
-      description: '(필수) 양식: 20XX년 X학기 리쿠르팅 - 과제 X (혹은 과제 O)',
+      description: '예: 20XX년 X학기 리쿠르팅',
       type: 'string',
+      validation: (rule) => rule.required(),
     }),
     defineField({
-      title: '리쿠르팅 서류 일정',
-      name: 'formSchedule',
-      description:
-        '"과제 X 문서" 기반으로 반영됩니다. "과제 O 문서"에서는 작성하지 않으셔도 됩니다.',
-      type: 'dateContent',
+      name: 'isActive',
+      title: '현재 리쿠르팅 일정으로 사용',
+      type: 'boolean',
+      initialValue: false,
+      validation: (rule) => rule.required(),
     }),
     defineField({
-      name: 'procedure',
-      title: '전체 지원 절차',
-      type: 'array',
-      of: [{ type: 'applyStepContent' }],
+      name: 'withAssignment',
+      title: '과제 포함 일정',
+      type: 'recruitingScheduleContent',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'withoutAssignment',
+      title: '과제 미포함 일정',
+      type: 'recruitingScheduleContent',
+      validation: (rule) => rule.required(),
     }),
   ],
   preview: {
     select: {
       title: 'title',
+      isActive: 'isActive',
+    },
+    prepare({ title, isActive }) {
+      return {
+        title,
+        subtitle: isActive ? '활성 일정' : '비활성 일정',
+      };
     },
   },
 });

--- a/studio/schemas/Types/recruitingScheduleContent.ts
+++ b/studio/schemas/Types/recruitingScheduleContent.ts
@@ -1,5 +1,38 @@
 import { defineField, defineType } from 'sanity';
 
+export const recruitingScheduleDepartmentOverride = defineType({
+  name: 'recruitingScheduleDepartmentOverride',
+  title: '부서별 일정 예외',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'department',
+      title: '부서',
+      type: 'reference',
+      to: [{ type: 'department' }],
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'formSchedule',
+      title: '부서별 서류 일정',
+      type: 'dateContent',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'procedure',
+      title: '부서별 지원 절차',
+      type: 'array',
+      of: [{ type: 'applyStepContent' }],
+      validation: (rule) => rule.required().min(1),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'department.basicInformation.name',
+    },
+  },
+});
+
 export default defineType({
   name: 'recruitingScheduleContent',
   type: 'object',
@@ -31,38 +64,7 @@ export default defineType({
       description:
         '기본 일정과 다른 부서만 선택해주세요. 선택한 부서는 서류 일정과 지원 절차를 모두 입력해야 합니다.',
       type: 'array',
-      of: [
-        {
-          type: 'object',
-          fields: [
-            defineField({
-              name: 'department',
-              title: '부서',
-              type: 'reference',
-              to: [{ type: 'department' }],
-              validation: (rule) => rule.required(),
-            }),
-            defineField({
-              name: 'formSchedule',
-              title: '부서별 서류 일정',
-              type: 'dateContent',
-              validation: (rule) => rule.required(),
-            }),
-            defineField({
-              name: 'procedure',
-              title: '부서별 지원 절차',
-              type: 'array',
-              of: [{ type: 'applyStepContent' }],
-              validation: (rule) => rule.required().min(1),
-            }),
-          ],
-          preview: {
-            select: {
-              title: 'department.basicInformation.name',
-            },
-          },
-        },
-      ],
+      of: [{ type: 'recruitingScheduleDepartmentOverride' }],
     }),
   ],
 });

--- a/studio/schemas/Types/recruitingScheduleContent.ts
+++ b/studio/schemas/Types/recruitingScheduleContent.ts
@@ -5,39 +5,64 @@ export default defineType({
   type: 'object',
   fields: [
     defineField({
-      name: 'scheduleWithoutAssignment',
-      title: '공식 일정으로 리쿠르팅 진행 (과제 미포함)',
-      type: 'boolean',
-      initialValue: false,
-    }),
-    defineField({
-      name: 'scheduleWithAssignment',
-      title: '공식 일정으로 리쿠르팅 진행 (과제 포함)',
-      type: 'boolean',
-      initialValue: false,
-    }),
-    defineField({
-      name: 'individualSchedule',
-      title: '부서 내부 일정으로 리쿠르팅 진행',
-      description:
-        '해당 항목을 선택할 경우, 아래의 "부서 내부 일정"의 하위 항목을 입력해주세요.',
-      type: 'boolean',
-      initialValue: false,
+      name: 'departments',
+      title: '적용 부서',
+      description: '이 일정으로 리쿠르팅할 부서를 모두 선택해주세요.',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'department' }] }],
+      validation: (rule) => rule.required().min(1),
     }),
     defineField({
       name: 'formSchedule',
-      title: '부서 내부 일정 - 서류 일정',
-      description:
-        '"부서 내부 일정으로 리쿠르팅 진행"을 선택하지 않을 시, 해당 항목은 비공개됩니다.',
+      title: '리쿠르팅 서류 일정',
       type: 'dateContent',
+      validation: (rule) => rule.required(),
     }),
     defineField({
       name: 'procedure',
-      title: '부서 내부 일정 - 전체 지원 절차',
-      description:
-        '"부서 내부 일정으로 리쿠르팅 진행"을 선택하지 않을 시, 해당 항목은 비공개됩니다.',
+      title: '전체 지원 절차',
       type: 'array',
       of: [{ type: 'applyStepContent' }],
+      validation: (rule) => rule.required().min(1),
+    }),
+    defineField({
+      name: 'departmentOverrides',
+      title: '부서별 일정 예외',
+      description:
+        '기본 일정과 다른 부서만 선택해주세요. 선택한 부서는 서류 일정과 지원 절차를 모두 입력해야 합니다.',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'department',
+              title: '부서',
+              type: 'reference',
+              to: [{ type: 'department' }],
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: 'formSchedule',
+              title: '부서별 서류 일정',
+              type: 'dateContent',
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: 'procedure',
+              title: '부서별 지원 절차',
+              type: 'array',
+              of: [{ type: 'applyStepContent' }],
+              validation: (rule) => rule.required().min(1),
+            }),
+          ],
+          preview: {
+            select: {
+              title: 'department.basicInformation.name',
+            },
+          },
+        },
+      ],
     }),
   ],
 });

--- a/studio/schemas/index.ts
+++ b/studio/schemas/index.ts
@@ -12,7 +12,9 @@ import informationContent from './Types/informationContent';
 import { mainPageContentTypes } from './Types/mainPageContent';
 import presenterContent from './Types/presenterContent';
 import { recruitingPageContentTypes } from './Types/recruitingPageContent';
-import recruitingScheduleContent from './Types/recruitingScheduleContent';
+import recruitingScheduleContent, {
+  recruitingScheduleDepartmentOverride,
+} from './Types/recruitingScheduleContent';
 import roadToProContent from './Types/roadToProContent';
 import skillContent from './Types/skillContent';
 import articleContent from './Types/articleContent';
@@ -39,6 +41,7 @@ export const schemaTypes = [
   inaWordContent,
   presenterContent,
   recruitingScheduleContent,
+  recruitingScheduleDepartmentOverride,
   dateContent,
   articleContent,
   article,


### PR DESCRIPTION
## 변경 사항
- 일정 소유형을 `withAssignment` / `withoutAssignment` 모델로 전환하고, 부서별 전체 override를 지원합니다.
- Gatsby는 활성 일정의 필수 내용과 참조를 검증하며, 오류가 있으면 fail-closed로 페이지를 생성하지 않습니다.
- bounded/idempotent backfill을 제공하고, fingerprint/allowlist 기반 resumable cleanup으로 안전하게 정리합니다.
- 한글 runbook과 GraphQL schema 배포 순서를 포함합니다.

## 동작 흐름
```mermaid
flowchart LR
    A[기존 O/X 일정 + 부서 applyProcedure] --> B[검증된 백필]
    B --> C[활성 일정]
    C --> D[Gatsby 검증/페이지 생성]
    D --> E[배포 확인]
    E --> F[허용 목록 cleanup]
```

## 검증
- Node 24.15.0에서 resolver/migration focused checks 통과.
- root/Studio typecheck+lint, Studio build/schema validate 통과.
- actionlint 1.7.12 및 YAML parse 통과.
- targeted Oxfmt 및 diff check 통과.
- synthetic export-based dry-runs 통과(일반 O-only 백필, no-op 재실행, 예상 draft/collision abort; 원격 API 미사용).

## 배포 및 마이그레이션 주의사항
- production Gatsby build, Sanity production migration/write/schema/GraphQL/Studio deploy, S3/live verification은 실행하지 않았습니다.
- merge만으로 migration이 자동 실행되지 않습니다. 사용자는 merge/release window에서 `docs/RS-MIG-01.md`를 따라 migration을 실행해야 합니다.
- full repo format check는 protected untracked `.pi-subagents/` 때문에 실패하지만, tracked changed files targeted format은 통과했습니다.
