### PR TITLE
fix: 리쿠르팅 표기를 리크루팅으로 변경

### DIFF
--- a/scripts/check-recruitingSchedule.ts
+++ b/scripts/check-recruitingSchedule.ts
@@ -33,7 +33,7 @@ const knownDepartmentIds = new Set(['design', 'engineering']);
 
 const schedule: RecruitingScheduleDocument = {
   _id: 'schedule-1',
-  title: '2026년 1학기 리쿠르팅',
+  title: '2026년 1학기 리크루팅',
   isActive: true,
   withAssignment: {
     departments: [department('design')],

--- a/src/containers/description/ApplyProcedure/index.tsx
+++ b/src/containers/description/ApplyProcedure/index.tsx
@@ -32,7 +32,7 @@ function ApplyProcedure({ applyProcedure }: ApplyProcedureProps) {
     return () => document.removeEventListener('mousedown', handleClose);
   }, [isWarningOpen]);
 
-  // 리쿠르팅을 안하면 null 반환
+  // 리크루팅을 안하면 null 반환
   if (!applyProcedure || applyProcedure.length === 0) return null;
 
   return (

--- a/studio/migrations/rs-mig-01-backfill/check.ts
+++ b/studio/migrations/rs-mig-01-backfill/check.ts
@@ -13,14 +13,14 @@ const documents: RawDocument[] = [
   {
     _id: 'o',
     _type: 'recruitingSchedule',
-    title: '2026년 1학기 리쿠르팅 - 과제 O',
+    title: '2026년 1학기 리크루팅 - 과제 O',
     formSchedule: { start: '2026-03-01', end: '2026-03-10' },
     procedure: [{ _key: 'o-step', step: '서류', schedule: '03.01' }],
   },
   {
     _id: 'x',
     _type: 'recruitingSchedule',
-    title: '2026년 1학기 리쿠르팅 - 과제 X',
+    title: '2026년 1학기 리크루팅 - 과제 X',
     isActive: false,
     formSchedule: { start: '2026-03-02', end: '2026-03-11' },
     procedure: [{ _key: 'x-step', step: '서류', schedule: '03.02' }],
@@ -115,7 +115,7 @@ const expectAbort = (
 
 const invalid = documents.map((document) =>
   document._id === 'x'
-    ? { ...document, title: '2026년 1학기 리쿠르팅 - 과제 O' }
+    ? { ...document, title: '2026년 1학기 리크루팅 - 과제 O' }
     : document,
 );
 expectAbort(

--- a/studio/schemas/Documents/recruitingPage.ts
+++ b/studio/schemas/Documents/recruitingPage.ts
@@ -3,7 +3,7 @@ import { defineField, defineType } from 'sanity';
 
 export default defineType({
   name: 'recruitingPage',
-  title: '리쿠르팅 랜딩',
+  title: '리크루팅 랜딩',
   type: 'document',
   icon,
   fields: [
@@ -39,6 +39,6 @@ export default defineType({
     }),
   ],
   preview: {
-    prepare: () => ({ title: '리쿠르팅 랜딩' }),
+    prepare: () => ({ title: '리크루팅 랜딩' }),
   },
 });

--- a/studio/schemas/Documents/recruitingSchedule.ts
+++ b/studio/schemas/Documents/recruitingSchedule.ts
@@ -10,13 +10,13 @@ export default defineType({
     defineField({
       title: '제목',
       name: 'title',
-      description: '예: 20XX년 X학기 리쿠르팅',
+      description: '예: 20XX년 X학기 리크루팅',
       type: 'string',
       validation: (rule) => rule.required(),
     }),
     defineField({
       name: 'isActive',
-      title: '현재 리쿠르팅 일정으로 사용',
+      title: '현재 리크루팅 일정으로 사용',
       type: 'boolean',
       initialValue: false,
       validation: (rule) => rule.required(),

--- a/studio/schemas/Types/informationContent.ts
+++ b/studio/schemas/Types/informationContent.ts
@@ -44,9 +44,9 @@ export default defineType({
     }),
     defineField({
       name: 'isRecruiting',
-      title: '리쿠르팅 활성화',
+      title: '리크루팅 활성화',
       description:
-        '활성화하면 리쿠르팅 랜딩과 부서 네비게이션에서 상세 페이지에 접근할 수 있습니다.',
+        '활성화하면 리크루팅 랜딩과 부서 네비게이션에서 상세 페이지에 접근할 수 있습니다.',
       type: 'boolean',
       initialValue: false,
       validation: (rule) => rule.required(),

--- a/studio/schemas/Types/recruitingScheduleContent.ts
+++ b/studio/schemas/Types/recruitingScheduleContent.ts
@@ -40,14 +40,14 @@ export default defineType({
     defineField({
       name: 'departments',
       title: '적용 부서',
-      description: '이 일정으로 리쿠르팅할 부서를 모두 선택해주세요.',
+      description: '이 일정으로 리크루팅할 부서를 모두 선택해주세요.',
       type: 'array',
       of: [{ type: 'reference', to: [{ type: 'department' }] }],
       validation: (rule) => rule.required().min(1),
     }),
     defineField({
       name: 'formSchedule',
-      title: '리쿠르팅 서류 일정',
+      title: '리크루팅 서류 일정',
       type: 'dateContent',
       validation: (rule) => rule.required(),
     }),

--- a/studio/structure.ts
+++ b/studio/structure.ts
@@ -21,16 +21,16 @@ export const structure: StructureResolver = (S) =>
       singleton(S, '메인 페이지', 'mainPage', 'mainPage'),
       S.listItem()
         .id('recruiting')
-        .title('리쿠르팅')
+        .title('리크루팅')
         .child(
           S.list()
             .id('recruiting-content')
-            .title('리쿠르팅')
+            .title('리크루팅')
             .items([
-              singleton(S, '리쿠르팅 랜딩', 'recruitingPage', 'recruitingPage'),
+              singleton(S, '리크루팅 랜딩', 'recruitingPage', 'recruitingPage'),
               S.documentTypeListItem('department').title('부서 상세'),
               S.documentTypeListItem('recruitingSchedule').title(
-                '공통 리쿠르팅 일정',
+                '공통 리크루팅 일정',
               ),
               S.documentTypeListItem('roadToPro').title('Road to Pro'),
             ]),


### PR DESCRIPTION
## Summary
- 사용자 및 CMS 내 리쿠르팅 표기를 리크루팅으로 통일
- 관련 일정 검증 스크립트와 마이그레이션 예시 문구 갱신

## Testing
- `rg -n -i "리쿠르팅" .` (no matches)
- `git diff --check`
- `pnpm typecheck`, `pnpm format:check` (registry DNS 접근 실패로 미실행)